### PR TITLE
Community - fix definition of owner key

### DIFF
--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -821,7 +821,7 @@
         "already_power_down":
             "You are already powering down %(AMOUNT)s %(LIQUID_TICKER)s (%(WITHDRAWN)s %(LIQUID_TICKER)s paid out so far). Note that if you change the power down amount the payout schedule will reset.",
         "delegating":
-            "You are delegating %(AMOUNT)s %(LIQUID_TICKER)s. That amount is locked up and not available to power down until the delegation is removed and a full reward period has passed.",
+            "You are delegating %(AMOUNT)s %(LIQUID_TICKER)s. That amount is locked up and not available to power down until the delegation is removed and 5 days have passed.",
         "per_week": "That's ~%(AMOUNT)s %(LIQUID_TICKER)s per week.",
         "warning":
             "Leaving less than %(AMOUNT)s %(VESTING_TOKEN)s in your account is not recommended and can leave your account in a unusable state.",


### PR DESCRIPTION
Replaces #8 by @economicstudio:

> Fix #7
>
>dont' use the term 'master key' since users may be consfused with mater password, which is totally different.

Also added a correction from https://github.com/steemit/condenser/pull/3139/files