### PR TITLE
Community - Fix wallet page so that transfer history is not corrupted

### DIFF
--- a/src/app/redux/GlobalReducer.js
+++ b/src/app/redux/GlobalReducer.js
@@ -78,7 +78,32 @@ export default function reducer(state = defaultState, action = {}) {
                 });
                 new_state = new_state.set('content', content);
             }
-            return state.mergeDeep(new_state);
+            // let transfer_history from new state override completely, otherwise
+            // deep merge may not work as intended.
+            let mergedState = state.mergeDeep(new_state);
+            return mergedState.update(
+                'accounts',
+                accountMap =>
+                    accountMap
+                        ? accountMap.map(
+                              (v, k) =>
+                                  new_state.hasIn([
+                                      'accounts',
+                                      k,
+                                      'transfer_history',
+                                  ])
+                                      ? v.set(
+                                            'transfer_history',
+                                            new_state.getIn([
+                                                'accounts',
+                                                k,
+                                                'transfer_history',
+                                            ])
+                                        )
+                                      : v
+                          )
+                        : accountMap
+            );
         }
 
         case RECEIVE_ACCOUNT: {

--- a/src/app/redux/GlobalReducer.test.js
+++ b/src/app/redux/GlobalReducer.test.js
@@ -36,6 +36,40 @@ describe('Global reducer', () => {
         );
     });
 
+    it('should replace transfer history for a RECEIVE_STATE action', () => {
+        // Arrange, payload has one account with transfer history, one without
+        const payload = {
+            accounts: Map({
+                fooman: Map({
+                    transfer_history: List([Map({ a: 1 })]),
+                }),
+                barman: Map({}),
+            }),
+        };
+
+         // Two accounts both with transfer history
+        const initial = reducer()
+            .setIn(
+                ['accounts', 'fooman', 'transfer_history'],
+                List([Map({ b: 2 })])
+            )
+            .setIn(
+                ['accounts', 'barman', 'transfer_history'],
+                List([Map({ c: 3 })])
+            );
+
+         // Act
+        const actual = reducer(initial, globalActions.receiveState(payload));
+        // Assert
+        expect(
+            actual.getIn(['accounts', 'fooman', 'transfer_history'])
+        ).toEqual(List([Map({ a: 1 })]));
+        // Payload had no transfer history, does not affect account.
+        expect(
+            actual.getIn(['accounts', 'barman', 'transfer_history'])
+        ).toEqual(List([Map({ c: 3 })]));
+    });
+
     it('should return correct state for a RECEIVE_ACCOUNT action', () => {
         // Arrange
         const payload = {


### PR DESCRIPTION
From @eonwarped #32 and https://github.com/steemit/condenser/pull/3061:

> This should resolve https://github.com/steemit/condenser/issues/2970 https://github.com/steemit/condenser/issues/2968 https://github.com/steemit/condenser/issues/2967.
> 
> The problem is that mergeDeep when given two parallel lists will merge each entry by index, and this causes some weird behavior when the two transfer history lists aren't exactly matching up. Instead, the transfer history should be replacing the old transfer history. This change attempts to do just that.
> 
> One problem is that I was unable to reproduce the linked errors predictably, so I will try to see if there's a sequence that can reproduce. For now, just wanted to show the proposed fix.
> 
> I believe this should only happen in RECEIVE_STATE, and not in the other pieces of code that merge accounts (since they are used on account fetch calls that do not contain transfer history).