### PR TITLE
Community - add powerdown amount

### DIFF
--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -6,12 +6,12 @@ import tt from 'counterpart';
 import { List } from 'immutable';
 import SavingsWithdrawHistory from 'app/components/elements/SavingsWithdrawHistory';
 import TransferHistoryRow from 'app/components/cards/TransferHistoryRow';
-import TransactionError from 'app/components/elements/TransactionError';
 import TimeAgoWrapper from 'app/components/elements/TimeAgoWrapper';
 import {
     numberWithCommas,
     vestingSteem,
     delegatedSteem,
+    powerdownSteem,
     pricePerSteem,
 } from 'app/utils/StateFunctions';
 import WalletSubMenu from 'app/components/elements/WalletSubMenu';
@@ -109,6 +109,7 @@ class UserWallet extends React.Component {
 
         let vesting_steem = vestingSteem(account.toJS(), gprops);
         let delegated_steem = delegatedSteem(account.toJS(), gprops);
+        let powerdown_steem = powerdownSteem(account.toJS(), gprops);
 
         let isMyAccount =
             currentUser && currentUser.get('username') === account.get('name');
@@ -401,10 +402,6 @@ class UserWallet extends React.Component {
             });
         }
 
-        const isWithdrawScheduled =
-            new Date(account.get('next_vesting_withdrawal') + 'Z').getTime() >
-            Date.now();
-
         const steem_balance_str = numberWithCommas(balance_steem.toFixed(3));
         const steem_orders_balance_str = numberWithCommas(
             steemOrders.toFixed(3)
@@ -413,6 +410,9 @@ class UserWallet extends React.Component {
         const received_power_balance_str =
             (delegated_steem < 0 ? '+' : '') +
             numberWithCommas((-delegated_steem).toFixed(3));
+        const powerdown_balance_str = numberWithCommas(
+            powerdown_steem.toFixed(3)
+        );
         const sbd_balance_str = numberWithCommas('$' + sbd_balance.toFixed(3)); // formatDecimal(account.sbd_balance, 3)
         const sbd_orders_balance_str = numberWithCommas(
             '$' + sbdOrders.toFixed(3)
@@ -689,20 +689,19 @@ class UserWallet extends React.Component {
                 </div>
                 <div className="UserWallet__balance row">
                     <div className="column small-12">
-                        {isWithdrawScheduled && (
+                        {powerdown_steem != 0 && (
                             <span>
                                 {tt(
                                     'userwallet_jsx.next_power_down_is_scheduled_to_happen'
-                                )}&nbsp;{' '}
+                                )}{' '}
                                 <TimeAgoWrapper
                                     date={account.get(
                                         'next_vesting_withdrawal'
                                     )}
-                                />.
+                                />{' '}
+                                {'(~' + powerdown_balance_str + ' STEEM)'}.
                             </span>
                         )}
-                        {/*toggleDivestError && <div className="callout alert">{toggleDivestError}</div>*/}
-                        <TransactionError opType="withdraw_vesting" />
                     </div>
                 </div>
                 {disabledWarning && (

--- a/src/app/utils/StateFunctions.js
+++ b/src/app/utils/StateFunctions.js
@@ -77,6 +77,23 @@ export function delegatedSteem(account, gprops) {
     return vesting_steemf;
 }
 
+// How much STEEM this account is powering down.
+export function powerdownSteem(account, gprops) {
+    const withdraw_rate_vests = parseFloat(
+        account.vesting_withdraw_rate.split(' ')[0]
+    );
+    const remaining_vests =
+        (parseFloat(account.to_withdraw) - parseFloat(account.withdrawn)) /
+        1000000;
+    const vests = Math.min(withdraw_rate_vests, remaining_vests);
+    const total_vests = parseFloat(gprops.total_vesting_shares.split(' ')[0]);
+    const total_vest_steem = parseFloat(
+        gprops.total_vesting_fund_steem.split(' ')[0]
+    );
+    const powerdown_steemf = total_vest_steem * (vests / total_vests);
+    return powerdown_steemf;
+}
+
 export function assetFloat(str, asset) {
     try {
         assert.equal(typeof str, 'string');


### PR DESCRIPTION
From @economicstudio #35:
> Close #34 (and also fix double space typo, explained in https://github.com/steemit/condenser/issues/3186)
> 
> This is moved from https://github.com/steemit/condenser/pull/3193 per @roadscape's request.
> 
> ![](https://user-images.githubusercontent.com/38183982/51787226-19d13580-2167-11e9-9105-ba089e702c67.png)
> > Currently, it only shows the powerdown schedule
> 
> ![](https://user-images.githubusercontent.com/38183982/51787230-2d7c9c00-2167-11e9-809a-c448b2c6fc46.png)
> > Add the powerdown amount information
> 
> Note that "~" is to indicate that it's approximate, since the powerdown amount is based on VEST not SP.
> 
> I also thought about adding an addition row in the "STEEM POWER" section, but it may require to add some message (like delegation information) and then translation is also needed which might be too much. So I've utilized the current powerdown schedule information area. Thanks.
> 
> ![](https://user-images.githubusercontent.com/38183982/56747728-67fdd100-6776-11e9-88b6-96640299cd09.png)
> > full screenshot on my dev server
> 
> 
> ps. I'm glad to see some community PRs were merged recently, and hope this will be merged soon too. Thank you!