### PR TITLE
Community - Witness vote removal confirmation

### DIFF
--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -155,7 +155,7 @@ class Witnesses extends React.Component {
                                         owner,
                                         !myVote
                                     )}
-                                    title={tt('g.vote')}
+                                    title={myVote === true ? tt('g.remove_vote') : tt('g.vote')}
                                 >
                                     {up}
                                 </a>
@@ -216,7 +216,7 @@ class Witnesses extends React.Component {
                                                     item,
                                                     false
                                                 )}
-                                                title={tt('g.vote')}
+                                                title={tt('g.remove_vote')}
                                             >
                                                 {up}
                                             </a>
@@ -439,6 +439,9 @@ module.exports = {
                         transactionActions.broadcastOperation({
                             type: 'account_witness_vote',
                             operation: { account: username, witness, approve },
+                            confirm: !approve
+                                ? 'You are about to remove your vote for this witness'
+                                : null
                         })
                     );
                 },


### PR DESCRIPTION
From @quochuy #41:

> - on the Witnesses page, update the title of the chevron icon to reflect either it is for voting or removing a vote
> - on the Witnesses page, display a confirmation modal before broadcasting a witness vote removal