### PR TITLE
Community - Prefilled transfers page

### DIFF
--- a/src/app/components/modules/Transfer.jsx
+++ b/src/app/components/modules/Transfer.jsx
@@ -50,6 +50,20 @@ class TransferForm extends Component {
         runTests();
 
         this.buildTransferAutocomplete();
+
+        const { transferPrefilledData } = this.props.initialValues;
+        if (transferPrefilledData) {
+            this.setState({
+                memo: {
+                    ...this.state.memo,
+                    value: transferPrefilledData.permlink
+                },
+                to: {
+                    ...this.state.to,
+                    value: transferPrefilledData.toAccount
+                }
+            });
+        }
     }
 
     buildTransferAutocomplete() {
@@ -216,11 +230,16 @@ class TransferForm extends Component {
         this.state.amount.props.onChange(this.balanceValue().split(' ')[0]);
     };
 
+    // TODO: seems we don't need this... remove ?
     onChangeTo = value => {
         this.state.to.props.onChange(value.toLowerCase().trim());
         this.setState({
             to: { ...this.state.to, value: value.toLowerCase().trim() },
         });
+    };
+
+    handleMemoChange = e => {
+        this.setState({ memo: { ...this.state.memo, value: e.target.value } });
     };
 
     render() {
@@ -478,6 +497,8 @@ class TransferForm extends Component {
                                 autoCapitalize="off"
                                 spellCheck="false"
                                 disabled={loading}
+                                value={this.state.memo.value}
+                                onChange={this.handleMemoChange}
                             />
                             <div className="error">
                                 {memo.touched && memo.error && memo.error}&nbsp;

--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -76,7 +76,53 @@ class UserWallet extends React.Component {
                 'https://blocktrades.us/unregistered_trade/sbd/eth';
         };
         this.shouldComponentUpdate = shouldComponentUpdate(this, 'UserWallet');
+        this.componentDidUpdate = () => {
+            const { currentUser } = this.props;
+            const postingPrivateKey = currentUser.getIn(['private_keys', 'posting_private']);
+
+            if (postingPrivateKey !== undefined) {
+                const transferPrefilledData = this.checkPrefilledHashParams();
+
+                if (transferPrefilledData) {
+                    this.props.showTransfer({
+                        to: null,
+                        asset: 'STEEM',
+                        transferType: 'Transfer to Account',
+                        transferPrefilledData: transferPrefilledData
+                    });
+                }
+            }
+        }
     }
+
+    checkPrefilledHashParams = () => {
+        const hash = window.location.hash;
+        const hashParams = hash.split('!');
+        let permlink, currency, amount, toAccount;
+
+        for(let hi=0; hi<hashParams.length; hi++) {
+            const param = hashParams[hi];
+            const [key, value] = param.split('=');
+            switch(key) {
+                case 'p':
+                    permlink = value;
+                    break;
+
+                case 't':
+                    toAccount = value;
+                    break;
+            }
+        }
+
+        if (permlink && toAccount) {
+            return {
+                permlink: permlink,
+                toAccount: toAccount,
+            };
+        }
+
+        return null;
+    };
 
     handleClaimRewards = account => {
         this.setState({ claimInProgress: true }); // disable the claim button


### PR DESCRIPTION
- parses hash from the URL (#!p=author/the-perm-link!t=toAccount) and calls showTransfer with the prefilled data
- upon mounting the Transfer component, set the state with prefilled data

![Screen Shot 2019-05-30 at 9 54 34 pm](https://user-images.githubusercontent.com/310654/58631350-a82c1280-8325-11e9-962a-6ca8d760ef94.jpg)
