### PR TITLE
Community - Consider stale witnesses as disabled

### DIFF
--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -103,8 +103,10 @@ class Witnesses extends React.Component {
             const thread = item.get('url');
             const myVote = witness_votes ? witness_votes.has(owner) : null;
             const signingKey = item.get('signing_key');
-            const isDisabled = signingKey == DISABLED_SIGNING_KEY;
             const lastBlock = item.get('last_confirmed_block_num');
+            const noBlock7days = (head_block - lastBlock) * 3 > 604800;
+            const isDisabled =
+                signingKey == DISABLED_SIGNING_KEY || noBlock7days;
             const votingActive = witnessVotesInProgress.has(owner);
             const classUp =
                 'Voting__button Voting__button-up' +


### PR DESCRIPTION
From @netuoso #80:

> Checks if witness has signed a block within the past 7 days; if not, displays with a strikethrough format and time witness has been disabled (copies logic for witnesses with null signing key)
> 
> Closes #79 