### PR TITLE
SPS UI Implementation Fix Show All Active Votes

### DIFF
--- a/src/app/components/modules/ProposalList/ProposalContainer.jsx
+++ b/src/app/components/modules/ProposalList/ProposalContainer.jsx
@@ -11,7 +11,7 @@ class ProposalContainer extends React.Component {
             isVoting: false,
             voteFailed: false,
             voteSucceeded: false,
-            isUpVoted: props.proposal.isUpVoted,
+            isUpVoted: props.proposal.upVoted,
         };
         this.id = this.props.proposal.id;
     }

--- a/src/app/redux/ProposalSaga.js
+++ b/src/app/redux/ProposalSaga.js
@@ -107,11 +107,11 @@ export function* listProposals({
     const mungedProposals = proposals.map(p => {
         console.log(
             'ProposalSaga->listProposals()::proposalVotesIds.indexOf(p.proposal_id)',
-            proposalVotesIds.indexOf(p.proposal_id),
+            proposalVotesIds.includes(p.proposal_id),
             proposalVotesIds
         );
         console.log('ProposalSaga->listProposals()::p', p, p.upVoted);
-        if (proposalVotesIds.indexOf(p.proposal_id) != -1) {
+        if (proposalVotesIds.includes(p.proposal_id)) {
             p.upVoted = true;
         } else {
             p.upVoted = false;

--- a/src/app/redux/ProposalSaga.js
+++ b/src/app/redux/ProposalSaga.js
@@ -107,11 +107,11 @@ export function* listProposals({
     const mungedProposals = proposals.map(p => {
         console.log(
             'ProposalSaga->listProposals()::proposalVotesIds.indexOf(p.proposal_id)',
-            proposalVotesIds.indexOf(p.proposal_id),
+            proposalVotesIds.includes(p.proposal_id),
             proposalVotesIds
         );
         console.log('ProposalSaga->listProposals()::p', p, p.upVoted);
-        if (proposalVotesIds.indexOf(p.proposal_id) != 1) {
+        if (proposalVotesIds.includes(p.proposal_id)) {
             p.upVoted = true;
         } else {
             p.upVoted = false;

--- a/src/app/redux/ProposalSaga.js
+++ b/src/app/redux/ProposalSaga.js
@@ -20,48 +20,6 @@ export function* listVotedOnProposalsCaller(action) {
     yield listVotedOnProposals(action.payload);
 }
 
-/*
-async function getVotesOnProposalById(proposal) {
-    let votes = [];
-    let nextVotes = [];
-    let beyondThisProposal = false;
-    while(true) {
-        nextVotes = call(
-            [api, api.listProposalVotesAsync],
-            [proposal],
-            100,
-            'by_proposal_voter',
-            'ascending',
-            'all'
-        );
-        votes.push(nextVotes);
-        if(nextVotes.count() < 100)
-            return votes;
-        beyondThisProposal = nextVotes.map(p => {
-            if(p.proposal_id != proposal)
-                return true;
-        })
-        if(beyondThisProposal)
-            return votes;
-    }
-}*/
-
-/*
-export function* getNextProposalVotes(proposalId, startVoter, limit) {
-    return yield call(
-        [api, api.listProposalVotesAsync],
-        [proposalId, startVoter],
-        limit,
-        'by_proposal_voter',
-        'ascending',
-        'all'
-    );
-}*/
-
-// export function* listVoterProposalsCaller(action) {
-//     yield listVoterProposals(action.payload);
-// }
-
 export function* listProposals({
     voter_id,
     last_proposal,
@@ -104,7 +62,7 @@ export function* listProposals({
 
     let proposalVotesIds = [];
     console.log('ProposalSaga->listProposals()::if(voter_id)', voter_id);
-    
+
     if (voter_id) {
 
         let proposalVotes = yield proposalIds.map(function* (pId) {

--- a/src/app/redux/ProposalSaga.js
+++ b/src/app/redux/ProposalSaga.js
@@ -107,11 +107,11 @@ export function* listProposals({
     const mungedProposals = proposals.map(p => {
         console.log(
             'ProposalSaga->listProposals()::proposalVotesIds.indexOf(p.proposal_id)',
-            proposalVotesIds.includes(p.proposal_id),
+            proposalVotesIds.indexOf(p.proposal_id),
             proposalVotesIds
         );
         console.log('ProposalSaga->listProposals()::p', p, p.upVoted);
-        if (proposalVotesIds.includes(p.proposal_id)) {
+        if (proposalVotesIds.indexOf(p.proposal_id) != 1) {
             p.upVoted = true;
         } else {
             p.upVoted = false;


### PR DESCRIPTION
What this does:

Continually queries the API to get all proposal votes on all viewed proposals.

Unfortunately we cannot determine ahead of time how many votes to ask for, or even where to stop receiving votes, so this solves this problem in what feels like a bit of a hacky way.