### PR TITLE
Community - fix username links

### DIFF
--- a/src/app/components/modules/ProposalList/Proposal.jsx
+++ b/src/app/components/modules/ProposalList/Proposal.jsx
@@ -252,7 +252,7 @@ function checkIfSameUser(usernamea, usernameb, valueIfSame = true) {
 function linkifyUsername(linkText, username = '') {
     if (username == '') username = linkText;
     return (
-        <a href={`https://steemit.com/@${username}/feed`} target="_blank">
+        <a href={`https://steemit.com/@${username}`} target="_blank">
             {linkText}
         </a>
     );


### PR DESCRIPTION
Links were heading to feed page of user instead of blog/home page of user. #97 