### PR TITLE
Bump minimist from 1.2.0 to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "koa-static-cache": "4.1.1",
         "lodash.debounce": "4.0.8",
         "mem-stat": "1.0.5",
-        "minimist": "1.2.0",
+        "minimist": "1.2.3",
         "mixpanel": "0.5.0",
         "moment": "^2.24.0",
         "mysql2": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6773,10 +6773,10 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+minimist@1.2.3, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
+  integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
 minimist@~0.0.1:
   version "0.0.10"


### PR DESCRIPTION
Opening instead of #132 - the `/`'s in the branch name are trouble for CI I believe

Bumps [minimist](https://github.com/substack/minimist) from 1.2.0 to 1.2.3.
- [Release notes](https://github.com/substack/minimist/releases)
- [Commits](https://github.com/substack/minimist/compare/1.2.0...1.2.3)

Signed-off-by: dependabot[bot] <support@github.com>