### PR TITLE
Improve proposal upvoted checking from O(N^2) to O(N)

### DIFF
--- a/src/app/redux/ProposalSaga.js
+++ b/src/app/redux/ProposalSaga.js
@@ -85,14 +85,13 @@ export function* listProposals({
                 return p.proposal.id;
             });
     }
-    const mungedProposals = proposals.map(p => {
-        if (proposalVotesIds.indexOf(p.proposal_id) != -1) {
-            p.upVoted = true;
-        } else {
-            p.upVoted = false;
-        }
-        return p;
-    });
+
+    // Use hashset to perform O(1) lookups
+    const votedSet = new Set(proposalVotesIds);
+    const mungedProposals = proposals.map(p => ({
+        ...p,
+        upVoted: votedSet.has(p.proposal_id)
+    }));
 
     yield put(proposalActions.receiveListProposals({ mungedProposals }));
     if (resolve && mungedProposals) {


### PR DESCRIPTION
Looping over proposals and each one use the indexOf (linear lookup) is inefficient, a better way is to use the hash set to perform a O(1) lookup.

Tested locally.
![image](https://github.com/user-attachments/assets/2d9135b8-f8bd-4b66-a0fa-2de62d972964)
