### PR TITLE
Withdrawl Routes for Power Down Options

### DIFF
--- a/src/app/components/elements/RouteSettings.jsx
+++ b/src/app/components/elements/RouteSettings.jsx
@@ -1,0 +1,269 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import tt from 'counterpart';
+import * as transactionActions from 'app/redux/TransactionReducer';
+import * as userActions from 'app/redux/UserReducer';
+import * as globalActions from 'app/redux/GlobalReducer';
+import Icon from 'app/components/elements/Icon';
+
+class RouteSettings extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            broadcasting: false,
+            errorMessage: undefined,
+            proxyAccount: '',
+            percentage: 100,
+            autoVest: false,
+        };
+    }
+
+    componentDidMount() {
+        this.updateRemainingPercentage(this.props.withdraw_routes);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.withdraw_routes !== this.props.withdraw_routes) {
+            this.updateRemainingPercentage(this.props.withdraw_routes);
+        }
+    }
+
+    updateRemainingPercentage = (routes) => {
+        if (!routes) return;
+        const totalRoutedPercentage = routes.reduce((total, route) => total + route.percent, 0);
+        const remainingPercentage = 100 - (totalRoutedPercentage / 100);
+        this.setState({ percentage: remainingPercentage });
+    }
+
+    removeWithdrawRoute = (toAccount) => {
+        this.setState({ broadcasting: true, errorMessage: undefined });
+        const { account, setWithdrawVestingRoute } = this.props;
+
+        // To remove a route, you set the percent to 0
+        setWithdrawVestingRoute({
+            account,
+            proxy: toAccount,
+            percent: 0,
+            autoVest: false,
+            successCallback: () => this.setState({ broadcasting: false }),
+            errorCallback: (error) => this.setState({ broadcasting: false, errorMessage: String(error) }),
+        });
+    };
+
+    setWithdrawRoute = (e) => {
+        e.preventDefault();
+        this.setState({ broadcasting: true, errorMessage: undefined });
+
+        const { account, setWithdrawVestingRoute, hideModal } = this.props;
+        const { proxyAccount, percentage, autoVest } = this.state;
+
+        setWithdrawVestingRoute({
+            account,
+            proxy: proxyAccount,
+            percent: Math.round(percentage * 100), // API expects percentage * 100
+            autoVest,
+            successCallback: () => {
+                this.setState({ broadcasting: false });
+                hideModal(); // Close modal on success
+            },
+            errorCallback: (error) => {
+                this.setState({ broadcasting: false, errorMessage: String(error) });
+            },
+        });
+    };
+
+    handleInputChange = (event) => {
+        const { name, value } = event.target;
+        this.setState({ [name]: value });
+    };
+    
+    handleCheckboxChange = (event) => {
+        const { name, checked } = event.target;
+        this.setState({ [name]: checked });
+    }
+
+    render() {
+        if (!this.props.account) return null; // Render nothing if account data is not available yet
+
+        const { broadcasting, errorMessage, proxyAccount, percentage, autoVest } = this.state;
+        const { withdraw_routes, hideModal } = this.props;
+
+        let totalRoutedPercentage = 0;
+        const currentRoutesList = withdraw_routes && withdraw_routes.map(route => {
+            totalRoutedPercentage += route.percent;
+            return (
+                <div key={route.to_account} className="row" style={{ borderBottom: '1px solid #eee', padding: '0.5rem 0', display: 'flex', alignItems: 'center' }}>
+                    <div className="column">
+                        <div><strong>@{route.to_account}</strong></div>
+                        <div className="secondary" style={{fontSize: '0.9rem'}}>{route.percent / 100}% of power down</div>
+                    </div>
+                    <div className="column shrink">
+                        <button className="button alert hollow circle" style={{marginBottom: 0, width: '2rem', height: '2rem', lineHeight: '2rem', padding: 0}} onClick={() => this.removeWithdrawRoute(route.to_account)} title={tt('g.remove')}>
+                            <span style={{fontSize: '1.5rem', fontWeight: 'bold', lineHeight: '1rem'}}>&times;</span>
+                        </button>
+                    </div>
+                </div>
+            );
+        });
+
+        const remainingPercentage = 100 - (totalRoutedPercentage / 100);
+
+        const currentRoutes = (
+            <div className="WithdrawRoutes">
+                <h4 style={{marginBottom: '0.25rem'}}>Current Withdraw Routes</h4>
+                <p className="secondary">Your active power down routing configurations.</p>
+                <div style={{ marginBottom: '1rem' }}>
+                    {withdraw_routes && withdraw_routes.length > 0 ? currentRoutesList : <p>No withdraw routes are set.</p>}
+                </div>
+                {withdraw_routes && withdraw_routes.length > 0 && (
+                     <div className="callout" style={{ backgroundColor: '#f7f7f7', padding: '0.75rem' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                            <span>Total routed:</span> <strong>{totalRoutedPercentage / 100}%</strong>
+                        </div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                            <span>Remaining to you:</span> <strong>{remainingPercentage}%</strong>
+                        </div>
+                    </div>
+                )}
+            </div>
+        );
+
+        return (
+            <div className="RouteSettingsModal" style={{ padding: '1.5rem', maxWidth: '38rem', margin: '0 auto' }}>
+                <div className="row">
+                    <h3 className="column" style={{marginBottom: '1rem'}}>{tt('userwallet_jsx.advanced_routes')}</h3>
+                </div>
+                
+                {currentRoutes}
+
+                <hr />
+
+                <h4 style={{marginBottom: '0.25rem'}}>Add New Route</h4>
+                <div className="row">
+                    <div className="column small-12">
+                        <label>
+                            Route To Account
+                            <input
+                                type="text"
+                                name="proxyAccount"
+                                value={proxyAccount}
+                                onChange={this.handleInputChange}
+                                placeholder="Account to receive power down payments"
+                                autoComplete="off"
+                            />
+                        </label>
+                        <label>
+                            Percentage (0-{remainingPercentage}%)
+                            <input
+                                type="number"
+                                name="percentage"
+                                value={percentage}
+                                min="0"
+                                max={remainingPercentage}
+                                onChange={this.handleInputChange}
+                            />
+                        </label>
+                         <label style={{marginBottom: '1rem'}}>
+                            <input
+                                type="checkbox"
+                                name="autoVest"
+                                checked={autoVest}
+                                onChange={this.handleCheckboxChange}
+                            />
+                            &nbsp; Auto Vest
+                             <div className="secondary" style={{fontSize: '0.8rem', paddingTop: '5px'}}>When enabled, funds will be automatically converted to STEEM Power in the recipient account.</div>
+                        </label>
+                    </div>
+                </div>
+
+                <div className="row">
+                    <div className="column small-12">
+                         <div className="callout info">
+                            <p style={{marginBottom: '0.5rem'}}><strong>Withdraw Route Information:</strong></p>
+                            <ul style={{marginBottom: 0}}>
+                                <li>This only sets up routing rules for future power downs.</li>
+                                <li>You must still initiate a power down separately.</li>
+                                <li>Auto-vest converts payments directly to STEEM Power.</li>
+                            </ul>
+                        </div>
+                        {errorMessage && <div className="callout alert"><p>{errorMessage}</p></div>}
+                    </div>
+                </div>
+
+                <div className="row">
+                    <div className="column small-12" style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
+                         <button type="button" className="button hollow" onClick={hideModal} style={{marginBottom: 0, marginRight: '0.5rem'}}>
+                            {tt('g.cancel')}
+                        </button>
+                        <button
+                            type="submit"
+                            className="button"
+                            onClick={this.setWithdrawRoute}
+                            disabled={broadcasting || !proxyAccount || percentage <= 0}
+                            style={{marginBottom: 0}}
+                        >
+                            {tt('g.continue')}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default connect(
+    (state, ownProps) => {
+        const values = state.user.get('advanced_defaults');
+        if (!values) return { ...ownProps, account: null, withdraw_routes: [] };
+
+        const accountName = values.get('account');
+        const routes = state.user.get('withdraw_routes');
+        
+        const withdraw_routes = routes && routes.toJS ? routes.toJS() : [];
+
+        return { 
+            ...ownProps, 
+            account: accountName,
+            withdraw_routes,
+        };
+    },
+    (dispatch) => ({
+        hideModal: () => {
+            dispatch(userActions.hideAdvanced());
+        },
+        setWithdrawVestingRoute: ({
+            account,
+            proxy,
+            percent,
+            autoVest,
+            successCallback,
+            errorCallback,
+        }) => {
+             const successCallbackWrapper = (...args) => {
+                // Refresh account data after transaction
+                dispatch(userActions.getWithdrawRoutes({ account }));
+                if (successCallback) return successCallback(...args);
+            };
+            const isRemove = percent === 0;
+             dispatch(
+                transactionActions.broadcastOperation({
+                    type: 'set_withdraw_vesting_route',
+                    operation: {
+                        from_account: account,
+                        to_account: proxy,
+                        percent: percent,
+                        auto_vest: autoVest,
+                    },
+                    confirm: isRemove
+                        ? tt('g.are_you_sure')
+                        : tt('userwallet_jsx.confirm_route_setup', {
+                              percent: percent / 100,
+                              account: proxy,
+                          }),
+                    successCallback: successCallbackWrapper,
+                    errorCallback,
+                })
+            );
+        },
+    })
+)(RouteSettings);

--- a/src/app/components/modules/Modals.jsx
+++ b/src/app/components/modules/Modals.jsx
@@ -16,6 +16,7 @@ import ConfirmTransactionForm from 'app/components/modules/ConfirmTransactionFor
 import Transfer from 'app/components/modules/Transfer';
 import SignUp from 'app/components/modules/SignUp';
 import Powerdown from 'app/components/modules/Powerdown';
+import RouteSettings from 'app/components/elements/RouteSettings';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import TermsAgree from 'app/components/modules/TermsAgree';
 
@@ -28,6 +29,7 @@ class Modals extends React.Component {
         show_signup_modal: false,
         show_bandwidth_error_modal: false,
         show_powerdown_modal: false,
+        show_advanced_modal: false,
         show_transfer_modal: false,
         show_confirm_modal: false,
         show_login_modal: false,
@@ -41,6 +43,7 @@ class Modals extends React.Component {
         show_confirm_modal: PropTypes.bool,
         show_transfer_modal: PropTypes.bool,
         show_powerdown_modal: PropTypes.bool,
+        show_advanced_modal: PropTypes.bool,
         show_bandwidth_error_modal: PropTypes.bool,
         show_signup_modal: PropTypes.bool,
         show_post_advanced_settings_modal: PropTypes.string,
@@ -50,6 +53,7 @@ class Modals extends React.Component {
         hideSignUp: PropTypes.func.isRequired,
         hideTransfer: PropTypes.func.isRequired,
         hidePowerdown: PropTypes.func.isRequired,
+        hideAdvanced: PropTypes.func.isRequired,
         hideBandwidthError: PropTypes.func.isRequired,
         hideVote: PropTypes.func.isRequired,
         notifications: PropTypes.object,
@@ -70,12 +74,14 @@ class Modals extends React.Component {
             show_confirm_modal,
             show_transfer_modal,
             show_powerdown_modal,
+            show_advanced_modal,
             show_signup_modal,
             show_bandwidth_error_modal,
             show_post_advanced_settings_modal,
             hideLogin,
             hideTransfer,
             hidePowerdown,
+            hideAdvanced,
             hideConfirm,
             hideSignUp,
             show_terms_modal,
@@ -131,6 +137,12 @@ class Modals extends React.Component {
                     <Reveal onHide={hidePowerdown} show={show_powerdown_modal}>
                         <CloseButton onClick={hidePowerdown} />
                         <Powerdown />
+                    </Reveal>
+                )}
+                {show_advanced_modal && (
+                    <Reveal onHide={hideAdvanced} show={show_advanced_modal}>
+                        <CloseButton onClick={hideAdvanced} />
+                        <RouteSettings />
                     </Reveal>
                 )}
                 {show_signup_modal && (
@@ -197,6 +209,7 @@ export default connect(
             show_confirm_modal: state.transaction.get('show_confirm_modal'),
             show_transfer_modal: state.user.get('show_transfer_modal'),
             show_powerdown_modal: state.user.get('show_powerdown_modal'),
+            show_advanced_modal: state.user.get('show_advanced_modal'),
             show_signup_modal: state.user.get('show_signup_modal'),
             show_vote_modal: state.user.get('show_vote_modal'),
             notifications: state.app.get('notifications'),
@@ -236,6 +249,10 @@ export default connect(
         hidePowerdown: e => {
             if (e) e.preventDefault();
             dispatch(userActions.hidePowerdown());
+        },
+        hideAdvanced: e => {
+            if (e) e.preventDefault();
+            dispatch(userActions.hideAdvanced());
         },
         hideSignUp: e => {
             if (e) e.preventDefault();

--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -246,6 +246,14 @@ class UserWallet extends React.Component {
             }
         };
 
+        const showAdvanced = (e) => {
+            e.preventDefault();
+            const name = account.get('name');
+            this.props.showAdvanced({
+                account: name,
+            });
+        };
+
         // Sum savings withrawals
         let savings_pending = 0,
             savings_sbd_pending = 0;
@@ -434,6 +442,11 @@ class UserWallet extends React.Component {
                 value: tt('userwallet_jsx.power_down'),
                 link: '#',
                 onClick: powerDown.bind(this, false),
+            },
+            {
+                value: tt('userwallet_jsx.advanced_routes'),
+                link: '#',
+                onClick: showAdvanced,
             },
         ];
         const dollar_menu = [

--- a/src/app/components/pages/UserProfile.jsx
+++ b/src/app/components/pages/UserProfile.jsx
@@ -33,6 +33,7 @@ import userIllegalContent from 'app/utils/userIllegalContent';
 import proxifyImageUrl from 'app/utils/ProxifyUrl';
 import SanitizedLink from 'app/components/elements/SanitizedLink';
 import DropdownMenu from 'app/components/elements/DropdownMenu';
+import RouteSettings from 'app/components/elements/RouteSettings';
 
 export default class UserProfile extends React.Component {
     constructor() {
@@ -49,6 +50,11 @@ export default class UserProfile extends React.Component {
         this.redirect();
     }
 
+    componentDidMount() {
+        const { accountname, getWithdrawRoutes } = this.props;
+        getWithdrawRoutes(accountname);
+    }
+
     shouldComponentUpdate(np, ns) {
         return (
             np.currentUser !== this.props.currentUser ||
@@ -57,7 +63,9 @@ export default class UserProfile extends React.Component {
             np.globalStatus !== this.props.globalStatus ||
             np.loading !== this.props.loading ||
             np.location.pathname !== this.props.location.pathname ||
-            ns.showResteem !== this.state.showResteem
+            ns.showResteem !== this.state.showResteem ||
+            np.show_advanced_modal !== this.props.show_advanced_modal ||
+            np.show_powerdown_modal !== this.props.show_powerdown_modal
         );
     }
 
@@ -93,6 +101,7 @@ export default class UserProfile extends React.Component {
                 accountname,
                 isMyAccount,
                 socialUrl,
+                show_advanced_modal,
                 routeParams: { section },
             },
             onPrint,
@@ -134,6 +143,7 @@ export default class UserProfile extends React.Component {
                         account={accountImm}
                         showTransfer={this.props.showTransfer}
                         showPowerdown={this.props.showPowerdown}
+                        showAdvanced={this.props.showAdvanced}
                         showVote={this.props.showVote}
                         currentUser={currentUser}
                         withdrawVesting={this.props.withdrawVesting}
@@ -357,6 +367,7 @@ export default class UserProfile extends React.Component {
                 </div>
                 {/* <div>{printLink}</div> */}
                 <div>{tab_content}</div>
+                {show_advanced_modal && <RouteSettings />}
             </div>
         );
     }
@@ -382,9 +393,14 @@ module.exports = {
                 accountname,
                 isMyAccount,
                 socialUrl,
+                show_advanced_modal: state.user.get('show_advanced_modal'),
+                show_powerdown_modal: state.user.get('show_powerdown_modal'),
             };
         },
         dispatch => ({
+            getWithdrawRoutes: (account) => {
+                dispatch(userActions.getWithdrawRoutes({ account }));
+            },
             showVote: () => {
                 dispatch(userActions.showVote());
             },
@@ -402,9 +418,12 @@ module.exports = {
                 dispatch(userActions.clearPowerdownDefaults());
             },
             showPowerdown: powerdownDefaults => {
-                console.log('power down defaults:', powerdownDefaults);
                 dispatch(userActions.setPowerdownDefaults(powerdownDefaults));
                 dispatch(userActions.showPowerdown());
+            },
+            showAdvanced: advancedDefaults => {
+                dispatch(userActions.setAdvancedDefaults(advancedDefaults));
+                dispatch(userActions.showAdvanced());
             },
             withdrawVesting: ({
                 account,

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -33,6 +33,7 @@
         "community_create": "CREATE A COMMUNITY",
         "community_description": "About",
         "confirm": "Confirm",
+        "continue": "Continue",
         "convert": "Convert",
         "date": "Date",
         "delete": "Delete",
@@ -1014,6 +1015,8 @@
         "power_up": "Power Up",
         "power_down": "Power Down",
         "delegate": "Delegate",
+        "advanced_routes": "Advanced Routes",
+        "route_settings": "Route Settings",
         "market": "Market",
         "convert_to_LIQUID_TOKEN": "Convert to %(LIQUID_TOKEN)s",
         "withdraw_LIQUID_TOKEN": "Withdraw %(LIQUID_TOKEN)s",
@@ -1031,7 +1034,8 @@
         "redeem_rewards": "Redeem Rewards (Transfer to Balance)",
         "buy_steem_or_steem_power": "Buy STEEM",
         "just_mortgage": "Staking by JUST",
-        "incorrect_account_format": "Incorrect account format"
+        "incorrect_account_format": "Incorrect account format",
+        "confirm_route_setup": "Are you sure you want to set up %(percent)s%% of your Steem Power withdrawal to go to @%(account)s?"
     },
     "powerdown_jsx": {
         "power_down": "Power Down",

--- a/src/app/redux/UserReducer.js
+++ b/src/app/redux/UserReducer.js
@@ -14,10 +14,14 @@ const SHOW_TRANSFER = 'user/SHOW_TRANSFER';
 const HIDE_TRANSFER = 'user/HIDE_TRANSFER';
 const SHOW_POWERDOWN = 'user/SHOW_POWERDOWN';
 const HIDE_POWERDOWN = 'user/HIDE_POWERDOWN';
+const SHOW_ADVANCED = 'user/SHOW_ADVANCED';
+const HIDE_ADVANCED = 'user/HIDE_ADVANCED';
 const SET_TRANSFER_DEFAULTS = 'user/SET_TRANSFER_DEFAULTS';
 const CLEAR_TRANSFER_DEFAULTS = 'user/CLEAR_TRANSFER_DEFAULTS';
 const SET_POWERDOWN_DEFAULTS = 'user/SET_POWERDOWN_DEFAULTS';
 const CLEAR_POWERDOWN_DEFAULTS = 'user/CLEAR_POWERDOWN_DEFAULTS';
+const SET_ADVANCED_DEFAULTS = 'user/SET_ADVANCED_DEFAULTS';
+const CLEAR_ADVANCED_DEFAULTS = 'user/CLEAR_ADVANCED_DEFAULTS';
 export const USERNAME_PASSWORD_LOGIN = 'user/USERNAME_PASSWORD_LOGIN';
 export const SET_USERNAME = 'user/SET_USERNAME';
 export const SET_USER = 'user/SET_USER';
@@ -48,6 +52,8 @@ export const SET_EXPIRING_VESTING_DELEGATIONS =
     'user/SET_EXPIRING_VESTING_DELEGATIONS';
 export const EXPIRING_VESTING_DELEGATIONS_LOADING =
     'user/EXPIRING_VESTING_DELEGATIONS_LOADING';
+export const GET_WITHDRAW_ROUTES = 'user/GET_WITHDRAW_ROUTES';
+export const SET_WITHDRAW_ROUTES = 'user/SET_WITHDRAW_ROUTES';
 export const RESET_ERROR = 'user/RESET_ERROR';
 export const CLAIM_PENDING_TRX = 'user/CLAIM_PENDING_TRX';
 
@@ -55,6 +61,8 @@ const defaultState = fromJS({
     current: null,
     show_login_modal: false,
     show_transfer_modal: false,
+    show_powerdown_modal: false,
+    show_advanced_modal: false,
     show_signup_modal: false,
     show_post_advanced_settings_modal: '', // formId,
     show_vote_modal: false,
@@ -64,6 +72,7 @@ const defaultState = fromJS({
     maybeLoggedIn: false,
     vestingDelegations: null,
     expiringVestingDelegations: null,
+    withdraw_routes: null,
 });
 
 export default function reducer(state = defaultState, action) {
@@ -130,6 +139,9 @@ export default function reducer(state = defaultState, action) {
         case EXPIRING_VESTING_DELEGATIONS_LOADING:
             return state.set('expiringVestingDelegationsLoading', payload);
 
+        case SET_WITHDRAW_ROUTES:
+            return state.set('withdraw_routes', fromJS(payload));
+
         case REMOVE_HIGH_SECURITY_KEYS: {
             if (!state.hasIn(['current', 'private_keys'])) return state;
             let empty = false;
@@ -173,6 +185,12 @@ export default function reducer(state = defaultState, action) {
         case HIDE_POWERDOWN:
             return state.set('show_powerdown_modal', false);
 
+        case SHOW_ADVANCED:
+            return state.set('show_advanced_modal', true);
+
+        case HIDE_ADVANCED:
+            return state.set('show_advanced_modal', false);
+
         case SET_TRANSFER_DEFAULTS:
             return state.set('transfer_defaults', fromJS(payload));
 
@@ -184,6 +202,11 @@ export default function reducer(state = defaultState, action) {
 
         case CLEAR_POWERDOWN_DEFAULTS:
             return state.remove('powerdown_defaults');
+        case SET_ADVANCED_DEFAULTS:
+            return state.set('advanced_defaults', fromJS(payload));
+
+        case CLEAR_ADVANCED_DEFAULTS:
+            return state.remove('advanced_defaults');
 
         case USERNAME_PASSWORD_LOGIN:
             return state; // saga
@@ -339,6 +362,15 @@ export const hidePowerdown = payload => ({
     type: HIDE_POWERDOWN,
     payload,
 });
+export const showAdvanced = payload => ({
+    type: SHOW_ADVANCED,
+    payload,
+});
+
+export const hideAdvanced = payload => ({
+    type: HIDE_ADVANCED,
+    payload,
+});
 
 export const setTransferDefaults = payload => ({
     type: SET_TRANSFER_DEFAULTS,
@@ -357,6 +389,16 @@ export const setPowerdownDefaults = payload => ({
 
 export const clearPowerdownDefaults = payload => ({
     type: CLEAR_POWERDOWN_DEFAULTS,
+    payload,
+});
+
+export const setAdvancedDefaults = payload => ({
+    type: SET_ADVANCED_DEFAULTS,
+    payload,
+});
+
+export const clearAdvancedDefaults = payload => ({
+    type: CLEAR_ADVANCED_DEFAULTS,
     payload,
 });
 
@@ -475,5 +517,15 @@ export const setExpiringVestingDelegations = payload => ({
 
 export const expiringVestingDelegationsLoading = payload => ({
     type: EXPIRING_VESTING_DELEGATIONS_LOADING,
+    payload,
+});
+
+export const getWithdrawRoutes = payload => ({
+    type: GET_WITHDRAW_ROUTES,
+    payload,
+});
+
+export const setWithdrawRoutes = payload => ({
+    type: SET_WITHDRAW_ROUTES,
     payload,
 });


### PR DESCRIPTION
This will enable Advance routes on the Wallet, that will allow users to add/remove routes of vesting withdrawal as mentioned on the #261 .
