### PR TITLE
Fix error handling in getStateAsync and Dockerfile ENV format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:10.0
 
 ARG SOURCE_COMMIT
-ENV SOURCE_COMMIT ${SOURCE_COMMIT}
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
 ARG DOCKER_TAG
-ENV DOCKER_TAG ${DOCKER_TAG}
+ENV DOCKER_TAG=${DOCKER_TAG}
 
 # yarn > npm
 #RUN npm install --global yarn
@@ -28,8 +28,8 @@ COPY . /var/app
 RUN mkdir tmp && \
     yarn test && yarn build
 
-ENV PORT 8080
-ENV NODE_ENV production
+ENV PORT=8080
+ENV NODE_ENV=production
 
 EXPOSE 8080
 

--- a/src/app/utils/steemApi.js
+++ b/src/app/utils/steemApi.js
@@ -3,14 +3,46 @@ import { api } from '@steemit/steem-js';
 import stateCleaner from 'app/redux/stateCleaner';
 
 export async function getStateAsync(url) {
-    // strip off query string
-    const path = url.split('?')[0];
+    try {
+        // strip off query string
+        const path = url.split('?')[0];
 
-    const raw = await api.getStateAsync(path);
+        const raw = await api.getStateAsync(path);
 
-    const cleansed = stateCleaner(raw);
+        const cleansed = stateCleaner(raw);
 
-    return cleansed;
+        return cleansed;
+    } catch (error) {
+        // Log error but don't throw - return empty state instead
+        // This prevents 5xx errors when API calls fail
+        console.error(
+            JSON.stringify({
+                msg: '~~ getStateAsync error ~~',
+                url,
+                error: error.message || error,
+            })
+        );
+
+        // Return empty state structure to allow page to render
+        // instead of showing 5xx error page
+        // Ensure stateCleaner receives a valid structure
+        const emptyState = {
+            accounts: {},
+            content: {},
+        };
+        try {
+            return stateCleaner(emptyState);
+        } catch (cleanerError) {
+            // If stateCleaner fails, return the empty state directly
+            console.error(
+                JSON.stringify({
+                    msg: '~~ stateCleaner error ~~',
+                    error: cleanerError.message || cleanerError,
+                })
+            );
+            return emptyState;
+        }
+    }
 }
 
 export async function fetchData(method, params, id) {


### PR DESCRIPTION
- Add try-catch in getStateAsync to prevent 5xx errors when API calls fail Returns empty state instead of throwing exceptions, allowing pages to render gracefully without data instead of showing error pages
- Fix Dockerfile ENV format warnings by using key=value syntax instead of legacy format