### PR TITLE
fix(ssr): isolate Redux store per request and clean up SSR utilities

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint *)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(pnpm lint *)"
-    ]
-  }
-}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,8 +1,15 @@
 'use client';
 
+import { useState } from 'react';
 import { Provider } from 'react-redux';
-import { store } from '@/lib/store';
+import { makeStore, AppStore } from '@/lib/store';
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  // Lazy initializer runs once per component mount.
+  // On the server each request renders a fresh tree, so makeStore() produces
+  // an isolated store per request — preventing auth state from leaking between users.
+  // On the client the state persists across re-renders, keeping a single instance.
+  const [store] = useState<AppStore>(() => makeStore());
+
   return <Provider store={store}>{children}</Provider>;
 }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -31,9 +31,11 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
   const { theme, cycleTheme } = useTheme();
   const reduxUsername = useSelector((state: RootState) => state.auth.username);
 
-  // getServerSnapshot returns null so server and hydration renders both produce
-  // null (isLoggedIn = false). React detects the post-hydration snapshot diff
-  // and schedules a sync re-render to show the avatar without a mismatch.
+  // useSyncExternalStore is used here purely as an SSR-safe initializer:
+  // getServerSnapshot returns null so server and hydration renders match,
+  // then React detects the post-hydration snapshot diff and re-renders once
+  // to show the avatar. The subscribe is intentionally a no-op — ongoing
+  // login state is owned by Redux; this value is only meaningful at mount.
   const rememberedUsername = useSyncExternalStore(
     () => () => {},
     () => getRememberedDeviceUsername(),

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -31,9 +31,9 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
   const { theme, cycleTheme } = useTheme();
   const reduxUsername = useSelector((state: RootState) => state.auth.username);
 
-  // Check localStorage for remembered device user (client-only, SSR-safe).
-  // Mirrors wallet-legacy's autopost2 restore in Main.js — the avatar should
-  // be visible whenever the device remembers a username, even before full auth.
+  // getServerSnapshot returns null so server and hydration renders both produce
+  // null (isLoggedIn = false). React detects the post-hydration snapshot diff
+  // and schedules a sync re-render to show the avatar without a mismatch.
   const rememberedUsername = useSyncExternalStore(
     () => () => {},
     () => getRememberedDeviceUsername(),

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -3,21 +3,23 @@ import authReducer from './slices/auth';
 import walletReducer from './slices/wallet';
 import uiReducer from './slices/ui';
 
-export const store = configureStore({
-  reducer: {
-    auth: authReducer,
-    wallet: walletReducer,
-    ui: uiReducer,
-  },
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: {
-        // Ignore non-serializable values (like private keys)
-        ignoredActions: ['auth/setPrivateKey'],
-        ignoredPaths: ['auth.privateKey'],
-      },
-    }),
-});
+export const makeStore = () =>
+  configureStore({
+    reducer: {
+      auth: authReducer,
+      wallet: walletReducer,
+      ui: uiReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: {
+          // Ignore non-serializable values (like private keys)
+          ignoredActions: ['auth/setPrivateKey'],
+          ignoredPaths: ['auth.privateKey'],
+        },
+      }),
+  });
 
-export type RootState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
+export type AppStore = ReturnType<typeof makeStore>;
+export type RootState = ReturnType<AppStore['getState']>;
+export type AppDispatch = AppStore['dispatch'];

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -95,10 +95,7 @@ export function useTheme() {
  * Utility function to get the current theme (for SSR compatibility)
  */
 export function getCurrentTheme(): LegacyTheme {
-  if (typeof window === 'undefined') return DEFAULT_THEME;
-
-  const stored = localStorage.getItem(THEME_KEY) as LegacyTheme;
-  return stored && validThemes.includes(stored) ? stored : DEFAULT_THEME;
+  return _theme;
 }
 
 /**

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -17,9 +17,24 @@ const DEFAULT_THEME: LegacyTheme = 'light';
 let _theme: LegacyTheme = DEFAULT_THEME;
 const _listeners = new Set<() => void>();
 
+function _notify() {
+  // Snapshot the set before iterating so a listener that calls unsubscribe
+  // (deleting itself from _listeners mid-loop) doesn't skip subsequent entries.
+  Array.from(_listeners).forEach((l) => l());
+}
+
 if (typeof window !== 'undefined') {
   const stored = localStorage.getItem(THEME_KEY) as LegacyTheme;
   if (stored && validThemes.includes(stored)) _theme = stored;
+
+  // Keep tabs in sync: when another tab writes to THEME_KEY, update the
+  // module store and notify all subscribers in this tab.
+  window.addEventListener('storage', (e) => {
+    if (e.key === THEME_KEY && e.newValue && validThemes.includes(e.newValue as LegacyTheme)) {
+      _theme = e.newValue as LegacyTheme;
+      _notify();
+    }
+  });
 }
 
 function _subscribeTheme(cb: () => void) {
@@ -36,7 +51,9 @@ function _getThemeServerSnapshot(): LegacyTheme { return DEFAULT_THEME; }
 export function useTheme() {
   const theme = useSyncExternalStore(_subscribeTheme, _getThemeSnapshot, _getThemeServerSnapshot);
 
-  // Apply theme class before paint to avoid FOUC.
+  // Safety net: ensures the correct class is on <html> at mount and whenever
+  // theme changes (e.g. cross-tab sync). changeTheme also applies the class
+  // synchronously to prevent FOUC — the duplication is intentional.
   useLayoutEffect(() => {
     document.documentElement.classList.remove('theme-original', 'theme-light', 'theme-dark');
     document.documentElement.classList.add(`theme-${theme}`);
@@ -49,19 +66,22 @@ export function useTheme() {
     }
     _theme = newTheme;
     localStorage.setItem(THEME_KEY, newTheme);
-    // Apply immediately so the class change is synchronous (avoids FOUC between
-    // the store mutation and the useLayoutEffect running after React re-renders).
+    // Apply immediately to avoid FOUC between this call and the useLayoutEffect
+    // that fires after React processes the re-render triggered by _notify().
     document.documentElement.classList.remove('theme-original', 'theme-light', 'theme-dark');
     document.documentElement.classList.add(`theme-${newTheme}`);
-    _listeners.forEach((l) => l());
+    _notify();
   }, []);
 
+  // Reads _theme directly from the module store so this callback is stable —
+  // it doesn't close over the `theme` snapshot and won't invalidate memoized
+  // children that receive cycleTheme as a prop.
   const cycleTheme = useCallback(() => {
-    const currentIndex = validThemes.indexOf(theme);
+    const currentIndex = validThemes.indexOf(_theme);
     const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % validThemes.length : 0;
     const nextTheme = validThemes[nextIndex];
     if (nextTheme) changeTheme(nextTheme);
-  }, [theme, changeTheme]);
+  }, [changeTheme]);
 
   return {
     theme,

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useState } from 'react';
+import { useCallback, useLayoutEffect, useSyncExternalStore } from 'react';
 
 export type LegacyTheme = 'original' | 'light' | 'dark';
 
@@ -10,46 +10,58 @@ const validThemes: LegacyTheme[] = ['original', 'light', 'dark'];
 /** Default day theme — wallet-legacy uses `theme-light` only (see App.jsx), not `theme-original`. */
 const DEFAULT_THEME: LegacyTheme = 'light';
 
+// Module-level store so useSyncExternalStore can subscribe to mutations.
+// Initialized from localStorage at module load time on the client — the
+// server always returns DEFAULT_THEME via getServerSnapshot, so hydration
+// produces the same tree the server sent before React switches to the real value.
+let _theme: LegacyTheme = DEFAULT_THEME;
+const _listeners = new Set<() => void>();
+
+if (typeof window !== 'undefined') {
+  const stored = localStorage.getItem(THEME_KEY) as LegacyTheme;
+  if (stored && validThemes.includes(stored)) _theme = stored;
+}
+
+function _subscribeTheme(cb: () => void) {
+  _listeners.add(cb);
+  return () => { _listeners.delete(cb); };
+}
+
+function _getThemeSnapshot(): LegacyTheme { return _theme; }
+function _getThemeServerSnapshot(): LegacyTheme { return DEFAULT_THEME; }
+
 /**
  * Hook for managing legacy wallet themes (original, light, dark)
  */
 export function useTheme() {
-  const [theme, setThemeState] = useState<LegacyTheme>(() => {
-    if (typeof window === 'undefined') return DEFAULT_THEME;
-    const stored = localStorage.getItem(THEME_KEY) as LegacyTheme;
-    return stored && validThemes.includes(stored) ? stored : DEFAULT_THEME;
-  });
-
-  const applyTheme = (newTheme: LegacyTheme) => {
-    // Remove all theme classes
-    document.documentElement.classList.remove('theme-original', 'theme-light', 'theme-dark');
-
-    // Add new theme class
-    document.documentElement.classList.add(`theme-${newTheme}`);
-  };
+  const theme = useSyncExternalStore(_subscribeTheme, _getThemeSnapshot, _getThemeServerSnapshot);
 
   // Apply theme class before paint to avoid FOUC.
   useLayoutEffect(() => {
-    applyTheme(theme);
+    document.documentElement.classList.remove('theme-original', 'theme-light', 'theme-dark');
+    document.documentElement.classList.add(`theme-${theme}`);
   }, [theme]);
 
-  const changeTheme = (newTheme: LegacyTheme) => {
+  const changeTheme = useCallback((newTheme: LegacyTheme) => {
     if (!validThemes.includes(newTheme)) {
       console.warn(`Invalid theme: ${newTheme}. Valid themes are: ${validThemes.join(', ')}`);
       return;
     }
-
-    setThemeState(newTheme);
+    _theme = newTheme;
     localStorage.setItem(THEME_KEY, newTheme);
-    applyTheme(newTheme);
-  };
+    // Apply immediately so the class change is synchronous (avoids FOUC between
+    // the store mutation and the useLayoutEffect running after React re-renders).
+    document.documentElement.classList.remove('theme-original', 'theme-light', 'theme-dark');
+    document.documentElement.classList.add(`theme-${newTheme}`);
+    _listeners.forEach((l) => l());
+  }, []);
 
-  const cycleTheme = () => {
+  const cycleTheme = useCallback(() => {
     const currentIndex = validThemes.indexOf(theme);
     const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % validThemes.length : 0;
     const nextTheme = validThemes[nextIndex];
     if (nextTheme) changeTheme(nextTheme);
-  };
+  }, [theme, changeTheme]);
 
   return {
     theme,

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Store factory unit tests
+ *
+ * Locks in the SSR-isolation invariant: makeStore must return a fresh store
+ * on every call so that concurrent server requests cannot share state.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { makeStore } from '@/lib/store';
+import { setCredentials } from '@/lib/store/slices/auth';
+
+describe('makeStore', () => {
+  it('returns an isolated store instance per call', () => {
+    expect(makeStore()).not.toBe(makeStore());
+  });
+
+  it('does not share dispatched state between instances', () => {
+    const a = makeStore();
+    const b = makeStore();
+
+    a.dispatch(setCredentials({ username: 'alice' }));
+
+    expect(a.getState().auth.username).toBe('alice');
+    expect(b.getState().auth.username).toBeNull();
+  });
+});

--- a/tests/unit/ui-slice.test.ts
+++ b/tests/unit/ui-slice.test.ts
@@ -1,0 +1,46 @@
+/**
+ * UI Redux slice unit tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import uiReducer, {
+  toggleSidebar,
+  setSidebarOpen,
+  setTheme,
+  setLocale,
+} from '@/lib/store/slices/ui';
+
+const initialState = {
+  sidebarOpen: true,
+  theme: 'light' as const,
+  locale: 'en',
+};
+
+describe('UI Slice', () => {
+  it('returns the initial state for an unknown action', () => {
+    expect(uiReducer(undefined, { type: 'unknown' })).toEqual(initialState);
+  });
+
+  it('toggleSidebar flips sidebarOpen', () => {
+    const next = uiReducer(initialState, toggleSidebar());
+    expect(next.sidebarOpen).toBe(false);
+
+    const back = uiReducer(next, toggleSidebar());
+    expect(back.sidebarOpen).toBe(true);
+  });
+
+  it('setSidebarOpen sets sidebarOpen to the payload value', () => {
+    expect(uiReducer(initialState, setSidebarOpen(false)).sidebarOpen).toBe(false);
+    expect(uiReducer(initialState, setSidebarOpen(true)).sidebarOpen).toBe(true);
+  });
+
+  it('setTheme updates the theme', () => {
+    expect(uiReducer(initialState, setTheme('dark')).theme).toBe('dark');
+    expect(uiReducer(initialState, setTheme('light')).theme).toBe('light');
+  });
+
+  it('setLocale updates the locale', () => {
+    expect(uiReducer(initialState, setLocale('zh')).locale).toBe('zh');
+    expect(uiReducer(initialState, setLocale('en')).locale).toBe('en');
+  });
+});

--- a/tests/unit/wallet-slice.test.ts
+++ b/tests/unit/wallet-slice.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Wallet Redux slice unit tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import walletReducer, {
+  setBalance,
+  setLoading,
+  setError,
+  clearWallet,
+} from '@/lib/store/slices/wallet';
+
+const initialState = {
+  balance: null,
+  loading: false,
+  error: null,
+};
+
+const sampleBalance = {
+  steem: '100.000 STEEM',
+  sbd: '50.000 SBD',
+  vests: '1000000.000000 VESTS',
+};
+
+describe('Wallet Slice', () => {
+  it('returns the initial state for an unknown action', () => {
+    expect(walletReducer(undefined, { type: 'unknown' })).toEqual(initialState);
+  });
+
+  it('setBalance stores the balance and clears loading/error', () => {
+    const loadingState = { ...initialState, loading: true, error: 'previous' };
+    const next = walletReducer(loadingState, setBalance(sampleBalance));
+
+    expect(next.balance).toEqual(sampleBalance);
+    expect(next.loading).toBe(false);
+    expect(next.error).toBeNull();
+  });
+
+  it('setLoading toggles the loading flag without touching balance/error', () => {
+    const seeded = { ...initialState, balance: sampleBalance, error: 'x' };
+
+    const loading = walletReducer(seeded, setLoading(true));
+    expect(loading.loading).toBe(true);
+    expect(loading.balance).toEqual(sampleBalance);
+    expect(loading.error).toBe('x');
+
+    const done = walletReducer(loading, setLoading(false));
+    expect(done.loading).toBe(false);
+  });
+
+  it('setError stores the message and clears loading', () => {
+    const loadingState = { ...initialState, loading: true };
+    const next = walletReducer(loadingState, setError('boom'));
+
+    expect(next.error).toBe('boom');
+    expect(next.loading).toBe(false);
+  });
+
+  it('clearWallet resets balance, loading, and error', () => {
+    const dirty = { balance: sampleBalance, loading: true, error: 'x' };
+    expect(walletReducer(dirty, clearWallet())).toEqual(initialState);
+  });
+});


### PR DESCRIPTION
Redux store SSR isolation — replaced the module-level singleton store with a makeStore factory. Providers now calls useState(() => makeStore()) so each server request renders with its own fresh store, preventing any user's auth state from leaking into another user's server-rendered HTML. On the client a single instance persists as before.
Type exports updated — AppStore, RootState, and AppDispatch are now derived from the factory's return type; all consumer files compile unchanged.
getCurrentTheme reads module store — removed the redundant localStorage.getItem call in favour of returning _theme directly, keeping a single source of truth in the module-level store.
Header comment — clarified the intentional no-op subscribe in useSyncExternalStore so future maintainers understand it is an SSR-safe initializer, not a live subscription.