### PR TITLE
feat(cache): Redis integration with server-side caching (Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@steemit/steem-js": "^1.0.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "ioredis": "^5.10.1",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "next-intl": "^4.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -579,105 +582,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -737,6 +724,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -793,28 +783,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -905,42 +891,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1707,79 +1687,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1857,42 +1824,36 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.30':
     resolution: {integrity: sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.30':
     resolution: {integrity: sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.30':
     resolution: {integrity: sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.30':
     resolution: {integrity: sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.30':
     resolution: {integrity: sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.30':
     resolution: {integrity: sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==}
@@ -1968,28 +1929,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2190,49 +2147,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2569,6 +2518,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
@@ -2742,6 +2695,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3359,6 +3316,10 @@ packages:
   intl-messageformat@11.2.1:
     resolution: {integrity: sha512-1gAVEUt3wEPvTqML4Fsw9klZV5j0vszQxayP/fi6gUroAc8AUHiNaisBKLWxybL1AdWq1mP07YV1q8v4N92ilQ==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -3687,28 +3648,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3732,6 +3689,12 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -4254,6 +4217,14 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -4463,6 +4434,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5553,6 +5527,8 @@ snapshots:
   '@inquirer/type@4.0.5(@types/node@25.6.0)':
     optionalDependencies:
       '@types/node': 25.6.0
+
+  '@ioredis/commands@1.5.1': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7312,6 +7288,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
@@ -7459,6 +7437,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -8282,6 +8262,20 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.2
       '@formatjs/icu-messageformat-parser': 3.5.4
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -8612,6 +8606,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -9188,6 +9186,12 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -9518,6 +9522,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 

--- a/src/app/api/auth/challenge/route.ts
+++ b/src/app/api/auth/challenge/route.ts
@@ -3,6 +3,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { setCSRFToken } from '@/lib/middleware';
+import { getRedis } from '@/lib/cache/redis';
+
+const CHALLENGE_TTL = 300; // 5 minutes
 
 export async function GET(request: NextRequest) {
   try {
@@ -26,6 +29,17 @@ export async function GET(request: NextRequest) {
 
     // Generate challenge
     const challenge = SteemService.generateChallenge(username);
+
+    // Store challenge in Redis for later verification
+    const redis = getRedis();
+    if (redis) {
+      await redis.set(
+        `auth:challenge:${username}`,
+        JSON.stringify({ challenge, createdAt: Date.now() }),
+        'EX',
+        CHALLENGE_TTL
+      );
+    }
 
     const response = NextResponse.json({
       success: true,

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { getRedis } from '@/lib/cache/redis';
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,9 +28,36 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Regenerate the expected challenge
-    // Note: In production, you'd store the challenge in a session/cache
-    // For now, we'll verify the signature is valid for the account
+    // Retrieve challenge from Redis
+    const redis = getRedis();
+    if (redis) {
+      const stored = await redis.get(`auth:challenge:${username}`);
+      if (!stored) {
+        return NextResponse.json(
+          { error: 'Invalid or expired challenge' },
+          { status: 401 }
+        );
+      }
+
+      const { challenge } = JSON.parse(stored) as { challenge: string; createdAt: number };
+
+      // Verify the signature against the stored challenge
+      const isValid = SteemService.verifyChallengeSignature(
+        challenge,
+        signedChallenge,
+        publicKey
+      );
+
+      if (!isValid) {
+        return NextResponse.json(
+          { error: 'Invalid signature' },
+          { status: 401 }
+        );
+      }
+
+      // Delete challenge (one-time use)
+      await redis.del(`auth:challenge:${username}`);
+    }
 
     // Get the account to verify the public key belongs to it
     const accounts = await SteemService.getAccounts([username]);
@@ -66,20 +94,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Verify the signature
-    // The challenge should be what was sent to the client
-    // Since we didn't store it, we'll verify the signature is valid for the public key
-    // In production, store the challenge in Redis/session
-
-    // For now, we'll trust the client sent a valid signature
-    // The signature verification would be: SteemService.verifyChallengeSignature(challenge, signedChallenge, publicKey)
-
     // Return success with account info
     return NextResponse.json({
       success: true,
       username: account.name,
       publicKey,
-      // Include some account info for the client
       account: {
         name: account.name,
         balance: account.balance,

--- a/src/app/api/broadcast/convert/route.ts
+++ b/src/app/api/broadcast/convert/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -32,10 +33,14 @@ export async function POST(request: NextRequest) {
 
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast convert error:', error);
     return NextResponse.json(

--- a/src/app/api/broadcast/delegate/route.ts
+++ b/src/app/api/broadcast/delegate/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -40,10 +41,14 @@ export async function POST(request: NextRequest) {
     // Broadcast the transaction
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast delegate error:', error);
     return NextResponse.json(

--- a/src/app/api/broadcast/power-down/route.ts
+++ b/src/app/api/broadcast/power-down/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -40,10 +41,14 @@ export async function POST(request: NextRequest) {
     // Broadcast the transaction
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast power down error:', error);
     return NextResponse.json(

--- a/src/app/api/broadcast/set-withdraw-vesting-route/route.ts
+++ b/src/app/api/broadcast/set-withdraw-vesting-route/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -32,10 +33,14 @@ export async function POST(request: NextRequest) {
 
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast set-withdraw-vesting-route error:', error);
     return NextResponse.json(

--- a/src/app/api/broadcast/transfer/route.ts
+++ b/src/app/api/broadcast/transfer/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -40,10 +41,14 @@ export async function POST(request: NextRequest) {
     // Broadcast the transaction
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast transfer error:', error);
     return NextResponse.json(

--- a/src/app/api/broadcast/vote/route.ts
+++ b/src/app/api/broadcast/vote/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -40,10 +41,14 @@ export async function POST(request: NextRequest) {
     // Broadcast the transaction
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast vote error:', error);
     return NextResponse.json(

--- a/src/app/api/broadcast/witness-vote/route.ts
+++ b/src/app/api/broadcast/witness-vote/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 import type { SignedTransaction } from '@/lib/steem/types';
 
 export async function POST(request: NextRequest) {
@@ -40,10 +41,14 @@ export async function POST(request: NextRequest) {
     // Broadcast the transaction
     const result = await SteemService.broadcastTransaction(signedTx);
 
-    return NextResponse.json({
-      success: true,
-      result,
-    });
+    // Invalidate Redis caches for this user
+    await cacheDeleteByPrefix('cache:query:accounts');
+    await cacheDeleteByPrefix(`cache:query:wallet-estimate-extras:${username}`);
+    await cacheDeleteByPrefix(`cache:query:withdraw-routes:${username}`);
+
+    const response = NextResponse.json({ success: true, result });
+    response.headers.set('X-Cache-Invalidate', username);
+    return response;
   } catch (error) {
     console.error('Broadcast witness vote error:', error);
     return NextResponse.json(

--- a/src/app/api/query/accounts/route.ts
+++ b/src/app/api/query/accounts/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -39,16 +40,24 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const accounts = await SteemService.getAccounts(usernames);
+    const cacheKey = `cache:query:accounts:${namesParam.length > 200 ? namesParam.substring(0, 200) : namesParam}`;
+    const result = await withCache(cacheKey, 10, 300, () =>
+      SteemService.getAccounts(usernames)
+    );
 
-    const response = NextResponse.json({ success: true, accounts });
+    const response = NextResponse.json({
+      success: true,
+      accounts: result.data,
+      ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
+    });
     response.headers.set('Cache-Control', 'public, s-maxage=10, stale-while-revalidate=60');
+    if (result.degraded) response.headers.set('X-Degraded', 'true');
     return response;
   } catch (error) {
     console.error('Error fetching accounts:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch accounts', details: (error as Error).message },
-      { status: 500 }
+      { error: 'Failed to fetch accounts', degraded: true },
+      { status: 503 }
     );
   }
 }

--- a/src/app/api/query/global-props/route.ts
+++ b/src/app/api/query/global-props/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -13,19 +14,23 @@ export async function GET(request: NextRequest) {
     });
     if (rateLimitError) return rateLimitError;
 
-    const props = await SteemService.getGlobalProperties();
+    const result = await withCache('cache:query:global-props', 3, 300, () =>
+      SteemService.getGlobalProperties()
+    );
 
     const response = NextResponse.json({
       success: true,
-      props,
+      props: result.data,
+      ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
     });
     response.headers.set('Cache-Control', 'public, s-maxage=3');
+    if (result.degraded) response.headers.set('X-Degraded', 'true');
     return response;
   } catch (error) {
     console.error('Error fetching global properties:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch global properties', details: (error as Error).message },
-      { status: 500 }
+      { error: 'Failed to fetch global properties', degraded: true },
+      { status: 503 }
     );
   }
 }

--- a/src/app/api/query/median-history-price/route.ts
+++ b/src/app/api/query/median-history-price/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,14 +13,29 @@ export async function GET(request: NextRequest) {
     });
     if (rateLimitError) return rateLimitError;
 
-    const price = await SteemService.getCurrentMedianHistoryPrice();
+    try {
+      const result = await withCache(
+        'cache:query:median-history-price',
+        60,
+        600,
+        () => SteemService.getCurrentMedianHistoryPrice()
+      );
 
-    const response = NextResponse.json({
-      success: true,
-      ...price,
-    });
-    response.headers.set('Cache-Control', 'public, s-maxage=60');
-    return response;
+      const response = NextResponse.json({
+        success: true,
+        ...result.data,
+        ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
+      });
+      response.headers.set('Cache-Control', 'public, s-maxage=60');
+      if (result.degraded) response.headers.set('X-Degraded', 'true');
+      return response;
+    } catch (error) {
+      console.error('median-history-price query error:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch median history price', degraded: true },
+        { status: 503 }
+      );
+    }
   } catch (error) {
     console.error('median-history-price query error:', error);
     return NextResponse.json(

--- a/src/app/api/query/price/route.ts
+++ b/src/app/api/query/price/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -13,38 +14,46 @@ export async function GET(request: NextRequest) {
     });
     if (rateLimitError) return rateLimitError;
 
-    const feedHistory = await SteemService.getFeedHistory();
+    const result = await withCache('cache:query:price', 60, 600, async () => {
+      const feedHistory = await SteemService.getFeedHistory();
 
-    // Calculate current price from feed history
-    // The base is the median price in SBD
-    // The quote is 1 STEEM
-    const history = feedHistory as Record<string, unknown> | undefined;
-    const medianHistory = history?.current_median_history as Record<string, unknown> | undefined;
-    const currentPrice = (medianHistory?.base_quote as string) || '0.000 SBD';
+      // Calculate current price from feed history
+      // The base is the median price in SBD
+      // The quote is 1 STEEM
+      const history = feedHistory as Record<string, unknown> | undefined;
+      const medianHistory = history?.current_median_history as Record<string, unknown> | undefined;
+      const currentPrice = (medianHistory?.base_quote as string) || '0.000 SBD';
 
-    // Parse price (format: "1.234 SBD")
-    const priceMatch = currentPrice.match(/[\d.]+/);
-    const price = priceMatch ? parseFloat(priceMatch[0]) : 0;
+      // Parse price (format: "1.234 SBD")
+      const priceMatch = currentPrice.match(/[\d.]+/);
+      const price = priceMatch ? parseFloat(priceMatch[0]) : 0;
 
-    // Get previous prices for history
-    const priceHistory = (history?.price_history as unknown[]) || [];
+      // Get previous prices for history
+      const priceHistory = (history?.price_history as unknown[]) || [];
+
+      return {
+        price: {
+          sbd: price,
+          base: currentPrice,
+          timestamp: new Date().toISOString(),
+        },
+        history: priceHistory.slice(0, 7), // Last 7 days
+      };
+    });
 
     const response = NextResponse.json({
       success: true,
-      price: {
-        sbd: price,
-        base: currentPrice,
-        timestamp: new Date().toISOString(),
-      },
-      history: priceHistory.slice(0, 7), // Last 7 days
+      ...result.data,
+      ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
     });
     response.headers.set('Cache-Control', 'public, s-maxage=60');
+    if (result.degraded) response.headers.set('X-Degraded', 'true');
     return response;
   } catch (error) {
     console.error('Error fetching price:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch price', details: (error as Error).message },
-      { status: 500 }
+      { error: 'Failed to fetch price', degraded: true },
+      { status: 503 }
     );
   }
 }

--- a/src/app/api/query/wallet-estimate-extras/route.ts
+++ b/src/app/api/query/wallet-estimate-extras/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -18,16 +19,29 @@ export async function GET(request: NextRequest) {
     const includeOpenOrders =
       request.nextUrl.searchParams.get('includeOpenOrders') === 'true';
 
-    const extras = await SteemService.getWalletEstimateExtras(username, {
-      includeOpenOrders,
-    });
+    try {
+      const result = await withCache(
+        `cache:query:wallet-estimate-extras:${username}:${includeOpenOrders}`,
+        60,
+        600,
+        () => SteemService.getWalletEstimateExtras(username, { includeOpenOrders })
+      );
 
-    const response = NextResponse.json({
-      success: true,
-      ...extras,
-    });
-    response.headers.set('Cache-Control', 'public, s-maxage=60');
-    return response;
+      const response = NextResponse.json({
+        success: true,
+        ...result.data,
+        ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
+      });
+      response.headers.set('Cache-Control', 'public, s-maxage=60');
+      if (result.degraded) response.headers.set('X-Degraded', 'true');
+      return response;
+    } catch (error) {
+      console.error('wallet-estimate-extras query error:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch wallet estimate extras', degraded: true },
+        { status: 503 }
+      );
+    }
   } catch (error) {
     console.error('wallet-estimate-extras query error:', error);
     return NextResponse.json(

--- a/src/app/api/query/wallet-prices/route.ts
+++ b/src/app/api/query/wallet-prices/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,19 +11,23 @@ export async function GET(request: NextRequest) {
     });
     if (rateLimitError) return rateLimitError;
 
-    const prices = await SteemService.getWalletPrices();
+    const result = await withCache('cache:query:wallet-prices', 60, 600, () =>
+      SteemService.getWalletPrices()
+    );
 
     const response = NextResponse.json({
       success: true,
-      ...prices,
+      ...result.data,
+      ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
     });
     response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=120');
+    if (result.degraded) response.headers.set('X-Degraded', 'true');
     return response;
   } catch (error) {
     console.error('wallet-prices query error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch wallet prices', details: (error as Error).message },
-      { status: 500 }
+      { error: 'Failed to fetch wallet prices', degraded: true },
+      { status: 503 }
     );
   }
 }

--- a/src/app/api/query/withdraw-routes/route.ts
+++ b/src/app/api/query/withdraw-routes/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,14 +17,29 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Missing username' }, { status: 400 });
     }
 
-    const routes = await SteemService.getWithdrawRoutesOutgoing(username);
+    try {
+      const result = await withCache(
+        `cache:query:withdraw-routes:${username}`,
+        60,
+        600,
+        () => SteemService.getWithdrawRoutesOutgoing(username)
+      );
 
-    const response = NextResponse.json({
-      success: true,
-      routes,
-    });
-    response.headers.set('Cache-Control', 'public, s-maxage=60');
-    return response;
+      const response = NextResponse.json({
+        success: true,
+        routes: result.data,
+        ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
+      });
+      response.headers.set('Cache-Control', 'public, s-maxage=60');
+      if (result.degraded) response.headers.set('X-Degraded', 'true');
+      return response;
+    } catch (error) {
+      console.error('withdraw-routes query error:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch withdraw routes', degraded: true },
+        { status: 503 }
+      );
+    }
   } catch (error) {
     console.error('withdraw-routes query error:', error);
     return NextResponse.json(

--- a/src/app/api/query/witnesses/route.ts
+++ b/src/app/api/query/witnesses/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
 
 export async function GET(request: NextRequest) {
   try {
@@ -24,14 +25,29 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const witnesses = await SteemService.getWitnessesByVote(limit);
+    try {
+      const result = await withCache(
+        `cache:query:witnesses:${limit}`,
+        600,
+        1800,
+        () => SteemService.getWitnessesByVote(limit)
+      );
 
-    const response = NextResponse.json({
-      success: true,
-      witnesses,
-    });
-    response.headers.set('Cache-Control', 'public, s-maxage=600, stale-while-revalidate=1800');
-    return response;
+      const response = NextResponse.json({
+        success: true,
+        witnesses: result.data,
+        ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
+      });
+      response.headers.set('Cache-Control', 'public, s-maxage=600, stale-while-revalidate=1800');
+      if (result.degraded) response.headers.set('X-Degraded', 'true');
+      return response;
+    } catch (error) {
+      console.error('Error fetching witnesses:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch witnesses', degraded: true },
+        { status: 503 }
+      );
+    }
   } catch (error) {
     console.error('Error fetching witnesses:', error);
     return NextResponse.json(

--- a/src/lib/cache/redis.ts
+++ b/src/lib/cache/redis.ts
@@ -1,0 +1,113 @@
+// Redis connection singleton and cache primitives
+// Falls back gracefully when REDIS_URL is not configured
+
+import Redis from 'ioredis';
+
+let redis: Redis | null = null;
+let redisUnavailable = false;
+
+export function getRedis(): Redis | null {
+  if (redis) return redis;
+  if (redisUnavailable) return null;
+
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    redisUnavailable = true;
+    return null;
+  }
+
+  try {
+    redis = new Redis(url, {
+      maxRetriesPerRequest: 3,
+      retryStrategy(times) {
+        if (times > 10) return null;
+        return Math.min(times * 100, 2000);
+      },
+      lazyConnect: true,
+      connectTimeout: 5000,
+    });
+
+    redis.on('error', (err) => {
+      console.warn('Redis connection error:', err.message);
+    });
+
+    redis.on('close', () => {
+      redis = null;
+      redisUnavailable = false;
+    });
+
+    return redis;
+  } catch {
+    redisUnavailable = true;
+    return null;
+  }
+}
+
+export interface CacheEntry<T> {
+  data: T;
+  degraded: boolean;
+  staleAge?: number;
+}
+
+export async function cacheGet<T>(
+  key: string,
+  ttl: number,
+  staleTtl: number
+): Promise<CacheEntry<T> | null> {
+  const r = getRedis();
+  if (!r) return null;
+
+  try {
+    const [raw, remaining] = await Promise.all([
+      r.get(key),
+      r.ttl(key),
+    ]);
+
+    if (!raw || remaining < 0) return null;
+
+    const totalTtl = ttl + staleTtl;
+    const age = totalTtl - remaining;
+    const data = JSON.parse(raw) as T;
+
+    if (age <= ttl) {
+      return { data, degraded: false };
+    }
+
+    return { data, degraded: true, staleAge: age };
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheSet<T>(
+  key: string,
+  ttl: number,
+  staleTtl: number,
+  data: T
+): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+
+  try {
+    const totalTtl = ttl + staleTtl;
+    await r.set(key, JSON.stringify(data), 'EX', totalTtl);
+  } catch {
+    // Cache write failure is non-critical
+  }
+}
+
+export async function cacheDeleteByPrefix(prefix: string): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+
+  try {
+    let cursor = '0';
+    do {
+      const [next, keys] = await r.scan(cursor, 'MATCH', `${prefix}*`, 'COUNT', 100);
+      if (keys.length > 0) await r.del(...keys);
+      cursor = next;
+    } while (cursor !== '0');
+  } catch {
+    // Cache delete failure is non-critical
+  }
+}

--- a/src/lib/cache/server-cache.ts
+++ b/src/lib/cache/server-cache.ts
@@ -1,0 +1,51 @@
+// Server-side stale-while-error cache wrapper
+// Uses Redis when available, falls back to direct fetcher execution
+
+import { cacheGet, cacheSet, getRedis } from './redis';
+
+export interface WithCacheResult<T> {
+  data: T;
+  degraded: boolean;
+  staleAge?: number;
+}
+
+/**
+ * Execute a fetcher with stale-while-error caching:
+ * 1. Check Redis for fresh data → return immediately
+ * 2. Try fetcher → on success, cache and return
+ * 3. On fetcher failure → return stale data if available
+ * 4. No stale data → throw (caller handles 503)
+ */
+export async function withCache<T>(
+  key: string,
+  ttl: number,
+  staleTtl: number,
+  fetcher: () => Promise<T>
+): Promise<WithCacheResult<T>> {
+  const redis = getRedis();
+
+  // No Redis → just run the fetcher
+  if (!redis) {
+    const data = await fetcher();
+    return { data, degraded: false };
+  }
+
+  // Check for fresh cached data
+  const cached = await cacheGet<T>(key, ttl, staleTtl);
+  if (cached && !cached.degraded) {
+    return { data: cached.data, degraded: false };
+  }
+
+  // Try fresh fetch
+  try {
+    const fresh = await fetcher();
+    await cacheSet(key, ttl, staleTtl, fresh);
+    return { data: fresh, degraded: false };
+  } catch (error) {
+    // Fresh fetch failed — serve stale if available
+    if (cached) {
+      return { data: cached.data, degraded: true, ...(cached.staleAge !== undefined && { staleAge: cached.staleAge }) };
+    }
+    throw error;
+  }
+}

--- a/src/lib/middleware/rate-limit.ts
+++ b/src/lib/middleware/rate-limit.ts
@@ -1,68 +1,120 @@
 // Rate limiting middleware
+// Uses Redis when available, falls back to in-memory Map
+
 import { NextRequest, NextResponse } from 'next/server';
+import { getRedis } from '@/lib/cache/redis';
 
 export interface RateLimitConfig {
   maxRequests: number;
   windowSeconds: number;
 }
 
-// In-memory rate limit store
-// In production, use Redis or similar
+// In-memory fallback for when Redis is unavailable
 interface RateLimitEntry {
   count: number;
   resetAt: number;
 }
 
-const rateLimitStore = new Map<string, RateLimitEntry>();
+const memoryStore = new Map<string, RateLimitEntry>();
 
-/**
- * Clean up expired entries from the store
- */
 function cleanupExpiredEntries(): void {
   const now = Date.now();
-  for (const [key, entry] of rateLimitStore.entries()) {
-    if (now > entry.resetAt) {
-      rateLimitStore.delete(key);
-    }
+  for (const [key, entry] of memoryStore.entries()) {
+    if (now > entry.resetAt) memoryStore.delete(key);
   }
 }
 
-// Run cleanup every 5 minutes
 if (typeof setInterval !== 'undefined') {
   setInterval(cleanupExpiredEntries, 5 * 60 * 1000);
 }
 
-/**
- * Get client IP address from request
- */
 function getClientIP(request: NextRequest): string {
-  // Check various headers for IP
   const forwardedFor = request.headers.get('x-forwarded-for');
   const realIP = request.headers.get('x-real-ip');
   const cfConnectingIP = request.headers.get('cf-connecting-ip');
 
   if (forwardedFor) {
-    // x-forwarded-for can contain multiple IPs, take the first one
     const parts = forwardedFor.split(',');
     return parts[0]?.trim() || 'unknown';
   }
-
-  if (realIP) {
-    return realIP;
-  }
-
-  if (cfConnectingIP) {
-    return cfConnectingIP;
-  }
-
-  // Fallback to a generic identifier
+  if (realIP) return realIP;
+  if (cfConnectingIP) return cfConnectingIP;
   return 'unknown';
 }
 
-/**
- * Rate limit by IP address
- * Returns error response if limit exceeded, null if OK
- */
+async function redisRateLimit(
+  key: string,
+  config: RateLimitConfig
+): Promise<NextResponse | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const windowStart = Math.floor(Date.now() / (config.windowSeconds * 1000));
+    const redisKey = `ratelimit:${key}:${windowStart}`;
+
+    const count = await redis.incr(redisKey);
+    if (count === 1) {
+      await redis.expire(redisKey, config.windowSeconds + 1);
+    }
+
+    if (count > config.maxRequests) {
+      const retryAfter = config.windowSeconds;
+      return NextResponse.json(
+        { error: 'Too many requests', retryAfter },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': retryAfter.toString(),
+            'X-RateLimit-Limit': config.maxRequests.toString(),
+            'X-RateLimit-Remaining': '0',
+          },
+        }
+      );
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function memoryRateLimit(
+  key: string,
+  config: RateLimitConfig
+): NextResponse | null {
+  const now = Date.now();
+  const windowMs = config.windowSeconds * 1000;
+
+  let entry = memoryStore.get(key);
+
+  if (!entry || now > entry.resetAt) {
+    entry = { count: 1, resetAt: now + windowMs };
+    memoryStore.set(key, entry);
+    return null;
+  }
+
+  entry.count++;
+
+  if (entry.count > config.maxRequests) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': retryAfter.toString(),
+          'X-RateLimit-Limit': config.maxRequests.toString(),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': new Date(entry.resetAt).toISOString(),
+        },
+      }
+    );
+  }
+
+  return null;
+}
+
 export async function rateLimit(
   request: NextRequest,
   action: string,
@@ -70,139 +122,53 @@ export async function rateLimit(
 ): Promise<NextResponse | null> {
   const ip = getClientIP(request);
   const key = `${ip}:${action}`;
-  const now = Date.now();
-  const windowMs = config.windowSeconds * 1000;
 
-  // Get or create entry
-  let entry = rateLimitStore.get(key);
+  // Try Redis first
+  const redisResult = await redisRateLimit(key, config);
+  if (redisResult) return redisResult;
 
-  if (!entry || now > entry.resetAt) {
-    // Create new entry
-    entry = {
-      count: 1,
-      resetAt: now + windowMs,
-    };
-    rateLimitStore.set(key, entry);
-    return null;
-  }
+  // Fallback to in-memory (also used when Redis is available but didn't block)
+  const memoryResult = memoryRateLimit(key, config);
+  if (memoryResult) return memoryResult;
 
-  // Increment counter
-  entry.count++;
-
-  // Check if limit exceeded
-  if (entry.count > config.maxRequests) {
-    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-    return NextResponse.json(
-      {
-        error: 'Too many requests',
-        retryAfter,
-      },
-      {
-        status: 429,
-        headers: {
-          'Retry-After': retryAfter.toString(),
-          'X-RateLimit-Limit': config.maxRequests.toString(),
-          'X-RateLimit-Remaining': '0',
-          'X-RateLimit-Reset': new Date(entry.resetAt).toISOString(),
-        },
-      }
-    );
-  }
-
-  // Update entry
-  rateLimitStore.set(key, entry);
-
-  // Add rate limit headers to successful requests
   return null;
 }
 
-/**
- * Rate limit by username (for authenticated users)
- * Returns error response if limit exceeded, null if OK
- */
 export async function rateLimitByUser(
   username: string | null,
   action: string,
   config: RateLimitConfig
 ): Promise<NextResponse | null> {
-  if (!username) {
-    // Fall back to IP-based rate limiting if no username
-    return null;
-  }
+  if (!username) return null;
 
   const key = `user:${username}:${action}`;
-  const now = Date.now();
-  const windowMs = config.windowSeconds * 1000;
 
-  // Get or create entry
-  let entry = rateLimitStore.get(key);
+  const redisResult = await redisRateLimit(key, config);
+  if (redisResult) return redisResult;
 
-  if (!entry || now > entry.resetAt) {
-    // Create new entry
-    entry = {
-      count: 1,
-      resetAt: now + windowMs,
-    };
-    rateLimitStore.set(key, entry);
-    return null;
-  }
-
-  // Increment counter
-  entry.count++;
-
-  // Check if limit exceeded
-  if (entry.count > config.maxRequests) {
-    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-    return NextResponse.json(
-      {
-        error: 'Too many requests',
-        retryAfter,
-      },
-      {
-        status: 429,
-        headers: {
-          'Retry-After': retryAfter.toString(),
-          'X-RateLimit-Limit': config.maxRequests.toString(),
-          'X-RateLimit-Remaining': '0',
-          'X-RateLimit-Reset': new Date(entry.resetAt).toISOString(),
-        },
-      }
-    );
-  }
-
-  // Update entry
-  rateLimitStore.set(key, entry);
-
-  return null;
+  return memoryRateLimit(key, config);
 }
 
-/**
- * Get rate limit info for a key
- */
 export function getRateLimitInfo(
   request: NextRequest,
   action: string
 ): { limit: number; remaining: number; resetAt: Date } | null {
   const ip = getClientIP(request);
   const key = `${ip}:${action}`;
-  const entry = rateLimitStore.get(key);
-
-  if (!entry) {
-    return null;
-  }
+  const entry = memoryStore.get(key);
+  if (!entry) return null;
 
   return {
     limit: entry.count,
-    remaining: Math.max(0, entry.count),
+    remaining: Math.max(0, config_maxRequests - entry.count),
     resetAt: new Date(entry.resetAt),
   };
 }
 
-/**
- * Reset rate limit for a key (admin function)
- */
+const config_maxRequests = 100;
+
 export function resetRateLimit(request: NextRequest, action: string): void {
   const ip = getClientIP(request);
   const key = `${ip}:${action}`;
-  rateLimitStore.delete(key);
+  memoryStore.delete(key);
 }

--- a/tests/unit/rate-limit-redis.test.ts
+++ b/tests/unit/rate-limit-redis.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock redis module — rate limiter uses getRedis() internally
+const mockRedisInstance = {
+  incr: vi.fn(),
+  expire: vi.fn(),
+};
+
+const mockGetRedis = vi.fn();
+
+vi.mock('@/lib/cache/redis', () => ({
+  getRedis: () => mockGetRedis(),
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+  cacheDeleteByPrefix: vi.fn(),
+}));
+
+import { rateLimit, rateLimitByUser } from '@/lib/middleware/rate-limit';
+
+function mockRequest(ip: string = '1.2.3.4'): NextRequest {
+  return {
+    headers: new Headers({ 'x-forwarded-for': ip }),
+  } as unknown as NextRequest;
+}
+
+describe('Redis rate limiting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRedis.mockReturnValue(mockRedisInstance);
+  });
+
+  it('allows request under the limit', async () => {
+    mockRedisInstance.incr.mockResolvedValueOnce(1);
+    mockRedisInstance.expire.mockResolvedValueOnce(1);
+
+    const result = await rateLimit(mockRequest(), 'query', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+
+    expect(result).toBeNull();
+    expect(mockRedisInstance.incr).toHaveBeenCalled();
+  });
+
+  it('blocks request over the limit', async () => {
+    mockRedisInstance.incr.mockResolvedValueOnce(11); // Over limit
+
+    const result = await rateLimit(mockRequest(), 'query', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(429);
+    const body = await result!.json();
+    expect(body.error).toBe('Too many requests');
+  });
+
+  it('sets expiry on first request in window', async () => {
+    mockRedisInstance.incr.mockResolvedValueOnce(1);
+    mockRedisInstance.expire.mockResolvedValueOnce(1);
+
+    await rateLimit(mockRequest(), 'query', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+
+    expect(mockRedisInstance.expire).toHaveBeenCalled();
+  });
+
+  it('does not set expiry on subsequent requests', async () => {
+    mockRedisInstance.incr.mockResolvedValueOnce(5);
+
+    await rateLimit(mockRequest(), 'query', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+
+    expect(mockRedisInstance.expire).not.toHaveBeenCalled();
+  });
+
+  it('falls back to in-memory when Redis is unavailable', async () => {
+    mockGetRedis.mockReturnValue(null);
+
+    const result = await rateLimit(mockRequest(), 'query', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+
+    // First request in memory store → allowed
+    expect(result).toBeNull();
+  });
+
+  it('falls back to in-memory when Redis throws', async () => {
+    mockRedisInstance.incr.mockRejectedValueOnce(new Error('Connection refused'));
+
+    const result = await rateLimit(mockRequest(), 'query', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+
+    // Falls back to memory, first request → allowed
+    expect(result).toBeNull();
+  });
+
+  it('rateLimitByUser works with username', async () => {
+    mockRedisInstance.incr.mockResolvedValueOnce(1);
+    mockRedisInstance.expire.mockResolvedValueOnce(1);
+
+    const result = await rateLimitByUser('alice', 'broadcast', {
+      maxRequests: 5,
+      windowSeconds: 60,
+    });
+
+    expect(result).toBeNull();
+    expect(mockRedisInstance.incr).toHaveBeenCalledWith(
+      expect.stringContaining('user:alice:broadcast')
+    );
+  });
+
+  it('rateLimitByUser returns null without username', async () => {
+    const result = await rateLimitByUser(null, 'broadcast', {
+      maxRequests: 5,
+      windowSeconds: 60,
+    });
+
+    expect(result).toBeNull();
+    expect(mockRedisInstance.incr).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server-cache.test.ts
+++ b/tests/unit/server-cache.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the redis module at the boundary
+const mockCacheGet = vi.fn();
+const mockCacheSet = vi.fn();
+const mockCacheDeleteByPrefix = vi.fn();
+const mockGetRedis = vi.fn();
+
+vi.mock('@/lib/cache/redis', () => ({
+  cacheGet: (...args: unknown[]) => mockCacheGet(...args),
+  cacheSet: (...args: unknown[]) => mockCacheSet(...args),
+  cacheDeleteByPrefix: (...args: unknown[]) => mockCacheDeleteByPrefix(...args),
+  getRedis: () => mockGetRedis(),
+}));
+
+import { withCache } from '@/lib/cache/server-cache';
+
+describe('withCache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: Redis is available
+    mockGetRedis.mockReturnValue({});
+  });
+
+  it('returns fresh data from Redis cache', async () => {
+    mockCacheGet.mockResolvedValueOnce({
+      data: { x: 1 },
+      degraded: false,
+    });
+
+    const result = await withCache('key', 10, 300, () => Promise.resolve({ x: 2 }));
+    expect(result.data).toEqual({ x: 1 });
+    expect(result.degraded).toBe(false);
+  });
+
+  it('calls fetcher and caches on cache miss', async () => {
+    mockCacheGet.mockResolvedValueOnce(null); // cache miss
+
+    const fetcher = vi.fn().mockResolvedValue({ x: 42 });
+
+    const result = await withCache('key', 10, 300, fetcher);
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(result.data).toEqual({ x: 42 });
+    expect(result.degraded).toBe(false);
+    expect(mockCacheSet).toHaveBeenCalledWith('key', 10, 300, { x: 42 });
+  });
+
+  it('returns stale data when fetcher fails', async () => {
+    mockCacheGet.mockResolvedValueOnce({
+      data: { x: 1 },
+      degraded: true,
+      staleAge: 120,
+    });
+
+    const fetcher = vi.fn().mockRejectedValue(new Error('RPC down'));
+
+    const result = await withCache('key', 10, 300, fetcher);
+
+    expect(result.data).toEqual({ x: 1 });
+    expect(result.degraded).toBe(true);
+    expect(result.staleAge).toBe(120);
+  });
+
+  it('throws when fetcher fails and no stale data', async () => {
+    mockCacheGet.mockResolvedValueOnce(null);
+
+    const fetcher = vi.fn().mockRejectedValue(new Error('RPC down'));
+
+    await expect(withCache('key', 10, 300, fetcher)).rejects.toThrow('RPC down');
+  });
+
+  it('bypasses cache when Redis is unavailable', async () => {
+    mockGetRedis.mockReturnValue(null);
+
+    const fetcher = vi.fn().mockResolvedValue({ x: 99 });
+
+    const result = await withCache('key', 10, 300, fetcher);
+
+    expect(result.data).toEqual({ x: 99 });
+    expect(result.degraded).toBe(false);
+    expect(mockCacheGet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the multi-level caching architecture (plan: `.claude/plans/lazy-dancing-breeze.md`).

### Redis infrastructure
- **ioredis** added as dependency
- `src/lib/cache/redis.ts`: connection singleton with `getRedis()`, `cacheGet`, `cacheSet`, `cacheDeleteByPrefix`. Gracefully returns `null` when `REDIS_URL` is not configured — app works identically without Redis.

### Server-side stale-while-error cache
- `src/lib/cache/server-cache.ts`: `withCache<T>(key, ttl, staleTtl, fetcher)` pattern:
  1. Check Redis for fresh data → return immediately
  2. Try fetcher (Steem RPC) → cache result on success
  3. On RPC failure → serve stale cached data with `degraded: true`
  4. No stale data → throw (503)

### Per-endpoint TTL strategy
| Endpoint | TTL | Stale TTL |
|----------|-----|-----------|
| accounts | 10s | 300s |
| global-props | 3s | 300s |
| wallet-prices | 60s | 600s |
| price | 60s | 600s |
| median-history-price | 60s | 600s |
| witnesses | 600s | 1800s |
| wallet-estimate-extras | 60s | 600s |
| withdraw-routes | 60s | 600s |

### Rate limiting fix
- Migrated from in-memory `Map` to Redis `INCR` + `EXPIRE` with fixed-window counters
- Falls back to in-memory when Redis is unavailable
- Fixes rate limit bypass in multi-instance (4-8 EC2) deployment

### Auth challenge fix (security)
- Challenge now stored in Redis (`auth:challenge:{username}`, TTL 5min)
- Login route retrieves challenge, verifies signature, then deletes (one-time use)
- Fixes replay vulnerability where challenge was never validated

### Cache invalidation
- All 7 broadcast routes invalidate relevant Redis caches after successful transaction
- `X-Cache-Invalidate` header on broadcast responses triggers client-side cache flush

## Deployment requirements
- **New env var**: `REDIS_URL` pointing to ElastiCache endpoint
- Without `REDIS_URL`, all features degrade gracefully — app behaves same as Phase 1

## Test plan
- [x] `pnpm verify` passes (type-check + lint + coverage 80.86% + build)
- [x] 182 tests passing (13 new tests for server-cache and rate-limit-redis)
- [ ] Manual: verify wallet loads with `REDIS_URL=redis://localhost:6379`
- [ ] Manual: verify wallet loads WITHOUT `REDIS_URL` (graceful fallback)
- [ ] Manual: broadcast a transfer, verify cached balance updates
- [ ] Manual: stop Steem RPC, verify stale data served with `degraded: true` in response