### PR TITLE
feat(wallet): implement keys and permissions page

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "react-qr-code": "^2.0.21",
     "react-redux": "^9.2.0",
     "shadcn": "^4.3.1",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      react-qr-code:
+        specifier: ^2.0.21
+        version: 2.0.21(react@19.2.5)
       react-redux:
         specifier: ^9.2.0
         version: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
@@ -4123,6 +4126,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qr.js@0.0.0:
+    resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -4164,6 +4170,11 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-qr-code@2.0.21:
+    resolution: {integrity: sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==}
+    peerDependencies:
+      react: '*'
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -9042,6 +9053,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qr.js@0.0.0: {}
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -9130,6 +9143,12 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-qr-code@2.0.21(react@19.2.5):
+    dependencies:
+      prop-types: 15.8.1
+      qr.js: 0.0.0
+      react: 19.2.5
 
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1):
     dependencies:

--- a/src/app/[locale]/[username]/page.tsx
+++ b/src/app/[locale]/[username]/page.tsx
@@ -17,6 +17,7 @@ import {
   AuthorRewardsSectionLazy,
   CurationRewardsSectionLazy,
   DelegationsSectionLazy,
+  PermissionsSectionLazy,
 } from '@/components/wallet/client-wrappers';
 import { normalizeProfile } from '@/lib/steem/normalize-profile';
 import { canManageBalanceForPageUrl } from '@/lib/auth/browser-storage';
@@ -191,7 +192,13 @@ export default function WalletPage() {
             isMyAccount={isMyAccount}
           />
         )}
-        {isPermissionsPath && <WalletSectionPlaceholder titleKey="keysAndPermissions" />}
+        {isPermissionsPath && (
+          <PermissionsSectionLazy
+            key={`permissions-${urlUsername}`}
+            username={urlUsername}
+            isMyAccount={isMyAccount}
+          />
+        )}
         {isPasswordPath && <WalletSectionPlaceholder titleKey="changePassword" />}
         {isCommunitiesPath && <WalletSectionPlaceholder titleKey="communities" />}
         {isCurationRewardsPath && (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -431,3 +431,9 @@
   border-bottom: 1px solid var(--border);
   background-color: var(--card);
 }
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+}

--- a/src/components/wallet/account-key-row.tsx
+++ b/src/components/wallet/account-key-row.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import QRCode from 'react-qr-code';
+import { QrCode } from 'lucide-react';
+import {
+  type AccountAuthType,
+  type AuthRoleKeys,
+  wifForPublicKey,
+} from '@/lib/wallet/account-keys';
+import { LoginForm } from '@/components/auth/login-form';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+export interface AccountKeyRowProps {
+  pubkey: string;
+  authType: AccountAuthType;
+  accountName: string;
+  roleKeys: AuthRoleKeys;
+  /** i18n key under wallet.permissions for private key title */
+  privateTitleKey: string;
+  onWifVisibleChange?: (visible: boolean) => void;
+}
+
+export function AccountKeyRow({
+  pubkey,
+  authType,
+  accountName,
+  roleKeys,
+  privateTitleKey,
+  onWifVisibleChange,
+}: AccountKeyRowProps) {
+  const t = useTranslations('wallet.permissions');
+  const tAuth = useTranslations('auth');
+  const [loginOpen, setLoginOpen] = useState(false);
+  const [qrOpen, setQrOpen] = useState(false);
+
+  const wif = useMemo(() => wifForPublicKey(pubkey, roleKeys), [pubkey, roleKeys]);
+
+  useEffect(() => {
+    onWifVisibleChange?.(!!wif);
+  }, [wif, onWifVisibleChange]);
+
+  const authTypeLabel = useMemo(() => {
+    const map: Record<AccountAuthType, string> = {
+      posting: t('authTypePosting'),
+      active: t('authTypeActive'),
+      owner: t('authTypeOwner'),
+      memo: t('authTypeMemo'),
+    };
+    return map[authType];
+  }, [authType, t]);
+
+  const qrText = wif ?? pubkey;
+  const qrIsPrivate = !!wif;
+
+  const handleLoginSuccess = useCallback(() => {
+    setLoginOpen(false);
+  }, []);
+
+  return (
+    <div className="ShowKey space-y-4 border-t border-border pt-4 first:border-t-0 first:pt-0">
+      <div>
+        <h5 className="text-sm font-semibold text-foreground">
+          {t('publicKeyTitle', { type: authTypeLabel })}
+        </h5>
+        <div className="mt-2 flex flex-wrap items-start gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="shrink-0"
+                aria-label={t('showQr')}
+                onClick={() => setQrOpen(true)}
+              >
+                <QrCode className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t('showQr')}</TooltipContent>
+          </Tooltip>
+          <code className="text-muted-foreground min-w-0 flex-1 break-all text-xs leading-relaxed">
+            {pubkey}
+          </code>
+        </div>
+      </div>
+
+      <div>
+        <h5 className="text-sm font-semibold text-foreground">{t(privateTitleKey)}</h5>
+        <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-stretch">
+          <Input
+            readOnly
+            value={wif ?? '•'.repeat(44)}
+            className="font-mono text-xs sm:flex-1"
+            aria-label={t('privateKeyMasked')}
+          />
+          <div className="flex shrink-0 items-center gap-2">
+            {wif ? (
+              <div className="rounded-md border border-border bg-background p-2">
+                <QRCode value={wif} size={64} />
+              </div>
+            ) : (
+              <Button type="button" variant="secondary" onClick={() => setLoginOpen(true)}>
+                {t('reveal')}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Dialog open={loginOpen} onOpenChange={setLoginOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{tAuth('login')}</DialogTitle>
+            <DialogDescription>{t('revealLoginHint')}</DialogDescription>
+          </DialogHeader>
+          <LoginForm
+            embedded
+            fixedUsername={accountName}
+            onLoginSuccess={handleLoginSuccess}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={qrOpen} onOpenChange={setQrOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              {qrIsPrivate
+                ? t('qrPrivateTitle', { type: authTypeLabel })
+                : t('qrPublicTitle', { type: authTypeLabel })}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex justify-center rounded-md border border-border bg-white p-4">
+            <QRCode value={qrText} size={180} />
+          </div>
+          <code className="text-muted-foreground block break-all text-center text-xs">{qrText}</code>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/wallet/client-wrappers.tsx
+++ b/src/components/wallet/client-wrappers.tsx
@@ -54,6 +54,14 @@ export const DelegationsSectionLazy = dynamic(
   { loading: RewardsSectionFallback, ssr: false }
 );
 
+export const PermissionsSectionLazy = dynamic(
+  () =>
+    import('@/components/wallet/permissions-section').then((mod) => ({
+      default: mod.PermissionsSection,
+    })),
+  { loading: RewardsSectionFallback, ssr: false }
+);
+
 export const WitnessesPageClient = dynamic(
   () => import('@/components/wallet/witness-vote-form').then((mod) => ({ default: mod.WitnessVoteForm })),
   {

--- a/src/components/wallet/permissions-section.tsx
+++ b/src/components/wallet/permissions-section.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Printer } from 'lucide-react';
+import { useSteemAccount } from '@/hooks/use-steem-account';
+import { useAuthRoleKeys } from '@/hooks/use-auth-role-keys';
+import {
+  getPublicKeysForAuth,
+  type AccountAuthType,
+  type AuthRoleKeys,
+} from '@/lib/wallet/account-keys';
+import type { SteemAccount } from '@/lib/steem/types';
+import { AccountKeyRow } from '@/components/wallet/account-key-row';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+
+const KEY_TAB_IDS = ['posting', 'active', 'owner', 'memo', 'public'] as const;
+type KeyTabId = (typeof KEY_TAB_IDS)[number];
+
+const PRIVATE_TITLE_KEYS: Record<AccountAuthType, string> = {
+  posting: 'postingPrivateTitle',
+  active: 'activePrivateTitle',
+  owner: 'ownerPrivateTitle',
+  memo: 'memoPrivateTitle',
+};
+
+function PermissionsKeyPanel({
+  authType,
+  account,
+  accountName,
+  roleKeys,
+  onAnyWifVisible,
+}: {
+  authType: AccountAuthType;
+  account: SteemAccount;
+  accountName: string;
+  roleKeys: AuthRoleKeys;
+  onAnyWifVisible: (visible: boolean) => void;
+}) {
+  const t = useTranslations('wallet.permissions');
+
+  const pubkeys = useMemo(() => getPublicKeysForAuth(account, authType), [account, authType]);
+
+  const permissionItems = t.raw(`${authType}PermissionItems`) as string[];
+
+  const descKeys =
+    authType === 'posting' || authType === 'active' ? (['desc1', 'desc2'] as const) : (['desc'] as const);
+
+  return (
+    <div className="key rounded-lg border border-border bg-card">
+      <div className="flex flex-col lg:flex-row">
+        <div className="flex-1 space-y-4 p-4 lg:p-6">
+          {descKeys.map((dk) => (
+            <p key={dk} className="text-muted-foreground text-sm leading-relaxed">
+              {t(`${authType}.${dk}`)}
+            </p>
+          ))}
+          {pubkeys.map((pubkey) => (
+            <AccountKeyRow
+              key={pubkey}
+              pubkey={pubkey}
+              authType={authType}
+              accountName={accountName}
+              roleKeys={roleKeys}
+              privateTitleKey={PRIVATE_TITLE_KEYS[authType]}
+              onWifVisibleChange={onAnyWifVisible}
+            />
+          ))}
+        </div>
+        <aside
+          className={cn(
+            'border-t border-border p-4 lg:w-[360px] lg:shrink-0 lg:border-t-0 lg:border-l',
+            'bg-muted/20'
+          )}
+        >
+          <h5 className="mb-3 text-base font-semibold">{t(`${authType}PermissionsTitle`)}</h5>
+          <p className="text-muted-foreground mb-3 text-sm">{t(`${authType}PermissionsIntro`)}</p>
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {Array.isArray(permissionItems) &&
+              permissionItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+          </ul>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export function PermissionsSection({
+  username,
+  isMyAccount,
+}: {
+  username: string;
+  isMyAccount: boolean;
+}) {
+  const t = useTranslations('wallet.permissions');
+  const { data: account, loading, error } = useSteemAccount(username);
+  const roleKeys = useAuthRoleKeys();
+  const [wifVisible, setWifVisible] = useState(false);
+  const [activeTab, setActiveTab] = useState<KeyTabId>('posting');
+
+  const sessionMatchesAccount =
+    isMyAccount && roleKeys.username?.toLowerCase() === username.toLowerCase();
+
+  const effectiveRoleKeys: AuthRoleKeys = sessionMatchesAccount
+    ? {
+        ownerKey: roleKeys.ownerKey,
+        activeKey: roleKeys.activeKey,
+        postingKey: roleKeys.postingKey,
+        memoKey: roleKeys.memoKey,
+      }
+    : { ownerKey: null, activeKey: null, postingKey: null, memoKey: null };
+
+  const handleWifVisible = useCallback((visible: boolean) => {
+    if (visible) setWifVisible(true);
+  }, []);
+
+  const handlePrint = () => {
+    if (typeof window !== 'undefined') window.print();
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-10 w-full max-w-2xl" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !account) {
+    return (
+      <p className="text-destructive text-sm" role="alert">
+        {error || t('loadError')}
+      </p>
+    );
+  }
+
+  if (!account.vesting_shares) {
+    return <Skeleton className="h-40 w-full" />;
+  }
+
+  return (
+    <div className="UserKeys max-w-6xl print:block">
+      {wifVisible && (
+        <div className="no-print mb-4 flex justify-end">
+          <Button type="button" variant="outline" size="sm" onClick={handlePrint}>
+            <Printer className="mr-2 size-4" />
+            {t('print')}
+          </Button>
+        </div>
+      )}
+
+      <div className="mb-8 flex flex-col gap-6 lg:flex-row lg:justify-between">
+        <div className="max-w-3xl space-y-4">
+          <h1 className="text-2xl font-bold tracking-tight">{t('pageTitle')}</h1>
+          <p className="text-muted-foreground text-base leading-relaxed">{t('intro1')}</p>
+          <p className="text-muted-foreground text-base leading-relaxed">{t('intro2')}</p>
+          <div>
+            <h5 className="mb-1 text-sm font-semibold">{t('learnMore')}</h5>
+            <a
+              href="https://steemit.com/steem/@steemitblog/steem-basics-understanding-private-keys-part-1"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-semibold text-primary hover:underline"
+            >
+              {t('learnMoreLink')}
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as KeyTabId)} className="gap-4">
+        <TabsList
+          variant="line"
+          className="no-print h-auto w-full flex-wrap justify-start gap-1 border border-border p-2"
+        >
+          {KEY_TAB_IDS.map((tabId) => (
+            <TabsTrigger key={tabId} value={tabId} className="px-3 py-1.5">
+              {t(`${tabId}Tab`)}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {(['posting', 'active', 'owner', 'memo'] as const).map((authType) => (
+          <TabsContent key={authType} value={authType} className="mt-0">
+            <PermissionsKeyPanel
+              authType={authType}
+              account={account}
+              accountName={username}
+              roleKeys={effectiveRoleKeys}
+              onAnyWifVisible={handleWifVisible}
+            />
+          </TabsContent>
+        ))}
+
+        <TabsContent value="public" className="mt-0">
+          <div className="rounded-lg border border-border bg-muted/30 p-6">
+            <p className="text-muted-foreground mb-4 text-sm leading-relaxed">{t('public.desc1')}</p>
+            <p className="text-muted-foreground text-sm leading-relaxed">
+              {t('public.desc2')}{' '}
+              <a
+                href={`https://steemdb.io/@${account.name}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-semibold text-primary hover:underline"
+              >
+                SteemDB
+              </a>
+            </p>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/hooks/use-auth-role-keys.ts
+++ b/src/hooks/use-auth-role-keys.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useSelector } from 'react-redux';
+import type { RootState } from '@/lib/store';
+import type { AuthRoleKeys } from '@/lib/wallet/account-keys';
+
+export function useAuthRoleKeys(): AuthRoleKeys & { username: string | null } {
+  return useSelector((state: RootState) => ({
+    username: state.auth.username,
+    ownerKey: state.auth.ownerKey,
+    activeKey: state.auth.activeKey,
+    postingKey: state.auth.postingKey,
+    memoKey: state.auth.memoKey,
+  }));
+}

--- a/src/hooks/use-steem-account.ts
+++ b/src/hooks/use-steem-account.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { cachedFetch } from '@/lib/cache/client-fetch';
+import type { SteemAccount } from '@/lib/steem/types';
+
+export function useSteemAccount(username: string) {
+  const [data, setData] = useState<SteemAccount | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+
+  const refetch = useCallback(async () => {
+    const name = username.trim().replace(/^@/, '');
+    if (!name) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError('');
+      const { data: response } = await cachedFetch<{
+        accounts?: SteemAccount[];
+        success?: boolean;
+        error?: string;
+      }>(`/api/query/accounts?names=${encodeURIComponent(name)}`, {
+        staleMs: 10_000,
+        maxAgeMs: 60_000,
+        noStore: true,
+      });
+
+      if (response.error || !response.accounts?.length) {
+        setError(response.error || 'Failed to fetch account');
+        setData(null);
+        return;
+      }
+
+      const acc = response.accounts[0];
+      setData(acc ?? null);
+    } catch {
+      setError('Failed to fetch account');
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    void Promise.resolve().then(refetch);
+  }, [refetch]);
+
+  return { data, loading, error, refetch };
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -162,6 +162,88 @@
       "invalidPercent": "Enter a valid percent between 0 and {max}.",
       "broadcastFailed": "Transaction failed. Check your key and try again."
     },
+    "permissions": {
+      "pageTitle": "Keys & Permissions",
+      "intro1": "Any password or key is more likely to get compromised the more it is used. That's why Steem uses a hierarchical key system to keep you safe. You are issued with Steem keys which have different permissions. For example, the Posting Key (which is intended to be used frequently) has a limited set of permissions for social actions that require less security. You'll need to be more careful with your Active Key since it has permissions to perform wallet related actions.",
+      "intro2": "Please take note of your Steem Keys listed below. Ideally, use a Password Manager (like 1Password or LastPass) or store an offline copy safely (on a piece of paper or on a file on a USB drive).",
+      "learnMore": "Learn more",
+      "learnMoreLink": "Understanding Private Keys Part 1",
+      "print": "Print",
+      "loadError": "Failed to load account keys.",
+      "reveal": "Reveal",
+      "revealLoginHint": "Sign in with your private key or master password to reveal keys that match this account.",
+      "showQr": "Show QR code",
+      "qrPublicTitle": "Public {type} key",
+      "qrPrivateTitle": "Private {type} key",
+      "publicKeyTitle": "Public {type} Key",
+      "privateKeyMasked": "Private key",
+      "authTypePosting": "Posting",
+      "authTypeActive": "Active",
+      "authTypeOwner": "Owner",
+      "authTypeMemo": "Memo",
+      "postingTab": "Posting Key",
+      "activeTab": "Active Key",
+      "ownerTab": "Owner Key",
+      "memoTab": "Memo Key",
+      "publicTab": "Public Keys",
+      "postingPrivateTitle": "Your Private Posting Key",
+      "activePrivateTitle": "Your Private Active Key",
+      "ownerPrivateTitle": "Your Private Owner Key",
+      "memoPrivateTitle": "Your Private Memo Key",
+      "postingPermissionsTitle": "Posting Key permissions",
+      "postingPermissionsIntro": "Use your Posting Key to:",
+      "postingPermissionItems": [
+        "Publish a post or comment",
+        "Edit a post or comment",
+        "Upvote or downvote",
+        "Resteem content",
+        "Follow people",
+        "Mute accounts"
+      ],
+      "activePermissionsTitle": "Active Key permissions",
+      "activePermissionsIntro": "Use your Active Key to:",
+      "activePermissionItems": [
+        "Transfer tokens",
+        "Power STEEM up or down",
+        "SBD conversion",
+        "Vote for witnesses",
+        "Place an order on an exchange",
+        "Certain profile changes",
+        "Publish a Witness price feed",
+        "Create a new user"
+      ],
+      "ownerPermissionsTitle": "Owner Key permissions",
+      "ownerPermissionsIntro": "Use your Owner Key to:",
+      "ownerPermissionItems": [
+        "Reset Owner, Active, and Posting keys",
+        "Recover your account",
+        "Decline voting rights"
+      ],
+      "memoPermissionsTitle": "Memo Key permissions",
+      "memoPermissionsIntro": "Use your Memo Key to:",
+      "memoPermissionItems": [
+        "Send an encrypted message",
+        "View an encrypted message"
+      ],
+      "posting": {
+        "desc1": "This key should be used for social networking actions, like posting, commenting and voting. This key has a limited set of permissions and it is not able to be used for monetary actions. So you can't lose money if someone else gets access to this key.",
+        "desc2": "Use this key to log in to other Steem-powered social networks like Steemit, Busy and eSteem. Store this key safely."
+      },
+      "active": {
+        "desc1": "This key has additional permissions for more sensitive monetary-related actions, like transferring and exchanging tokens.",
+        "desc2": "When performing a wallet related action, you may be prompted to authenticate with your Active key. You should only enter your Active Key into apps which you trust because anyone with access to this key can take your tokens. Do yourself a favor and store this key safely to avoid losing tokens in the future."
+      },
+      "owner": {
+        "desc": "The owner key is required to change the other keys. This key has additional permissions to recover your account or change your other keys. It's the most important key and should be securely stored offline."
+      },
+      "memo": {
+        "desc": "The Memo key can encrypt and decrypt private messages sent through the blockchain. If you received a private message you would like to decrypt, use the key with the minimum necessary authority—in this case the Memo key."
+      },
+      "public": {
+        "desc1": "Each Steem Key has a public and private key to encrypt and decrypt data. Public keys are associated with usernames and can be used to look up associated transactions on the blockchain. Your public keys are not required for login on Steemit.com and you don't need to store these safely.",
+        "desc2": "View public key information for this account (in the 'Authorities' module):"
+      }
+    },
     "convertSbd": {
       "title": "Convert SBD to STEEM",
       "dialogDescription": "Request conversion of SBD to STEEM using the median price.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -153,6 +153,88 @@
       "invalidPercent": "Introduce un porcentaje válido entre 0 y {max}.",
       "broadcastFailed": "La transacción falló. Revisa tu clave e inténtalo de nuevo."
     },
+    "permissions": {
+      "pageTitle": "Claves y permisos",
+      "intro1": "Cuantas más veces se usa una contraseña o clave, más probable es que se comprometa. Por eso Steem usa un sistema jerárquico de claves. La clave de publicación tiene permisos limitados para acciones sociales; la clave activa permite operaciones de billetera y requiere más cuidado.",
+      "intro2": "Anote sus claves Steem que aparecen abajo. Use un gestor de contraseñas (1Password, LastPass) o guarde una copia offline de forma segura.",
+      "learnMore": "Más información",
+      "learnMoreLink": "Entender las claves privadas (parte 1)",
+      "print": "Imprimir",
+      "loadError": "No se pudieron cargar las claves de la cuenta.",
+      "reveal": "Mostrar",
+      "revealLoginHint": "Inicia sesión con tu clave privada o contraseña maestra para mostrar las claves de esta cuenta.",
+      "showQr": "Mostrar código QR",
+      "qrPublicTitle": "Clave pública {type}",
+      "qrPrivateTitle": "Clave privada {type}",
+      "publicKeyTitle": "Clave pública {type}",
+      "privateKeyMasked": "Clave privada",
+      "authTypePosting": "Publicación",
+      "authTypeActive": "Activa",
+      "authTypeOwner": "Propietario",
+      "authTypeMemo": "Memo",
+      "postingTab": "Clave de publicación",
+      "activeTab": "Clave activa",
+      "ownerTab": "Clave de propietario",
+      "memoTab": "Clave memo",
+      "publicTab": "Claves públicas",
+      "postingPrivateTitle": "Tu clave privada de publicación",
+      "activePrivateTitle": "Tu clave privada activa",
+      "ownerPrivateTitle": "Tu clave privada de propietario",
+      "memoPrivateTitle": "Tu clave privada memo",
+      "postingPermissionsTitle": "Permisos de la clave de publicación",
+      "postingPermissionsIntro": "Usa tu clave de publicación para:",
+      "postingPermissionItems": [
+        "Publicar o comentar",
+        "Editar publicación o comentario",
+        "Votar a favor o en contra",
+        "Resteem",
+        "Seguir usuarios",
+        "Silenciar cuentas"
+      ],
+      "activePermissionsTitle": "Permisos de la clave activa",
+      "activePermissionsIntro": "Usa tu clave activa para:",
+      "activePermissionItems": [
+        "Transferir tokens",
+        "Power up o power down STEEM",
+        "Conversión SBD",
+        "Votar testigos",
+        "Orden en un exchange",
+        "Cambios de perfil",
+        "Publicar feed de precio de testigo",
+        "Crear un usuario nuevo"
+      ],
+      "ownerPermissionsTitle": "Permisos de la clave de propietario",
+      "ownerPermissionsIntro": "Usa tu clave de propietario para:",
+      "ownerPermissionItems": [
+        "Restablecer claves owner, active y posting",
+        "Recuperar tu cuenta",
+        "Rechazar derechos de voto"
+      ],
+      "memoPermissionsTitle": "Permisos de la clave memo",
+      "memoPermissionsIntro": "Usa tu clave memo para:",
+      "memoPermissionItems": [
+        "Enviar mensaje cifrado",
+        "Ver mensaje cifrado"
+      ],
+      "posting": {
+        "desc1": "Usa esta clave para publicar, comentar y votar. No permite acciones monetarias.",
+        "desc2": "Úsala para iniciar sesión en redes Steem como Steemit, Busy y eSteem. Guárdala con seguridad."
+      },
+      "active": {
+        "desc1": "Tiene permisos para transferencias y operaciones sensibles con tokens.",
+        "desc2": "Solo introduce tu clave activa en aplicaciones de confianza; quien la tenga puede tomar tus tokens."
+      },
+      "owner": {
+        "desc": "Necesaria para cambiar otras claves y recuperar la cuenta. Debe guardarse offline de forma segura."
+      },
+      "memo": {
+        "desc": "Cifra y descifra mensajes privados en la cadena. Para descifrar, usa la clave con la autoridad mínima: la memo."
+      },
+      "public": {
+        "desc1": "Cada clave Steem tiene parte pública y privada. Las públicas no son necesarias para iniciar sesión en Steemit.",
+        "desc2": "Ver información de claves públicas de esta cuenta (módulo «Authorities»):"
+      }
+    },
     "convertSbd": {
       "title": "Convertir SBD a STEEM",
       "dialogDescription": "Solicitar conversión de SBD a STEEM según el precio mediano.",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -162,6 +162,88 @@
       "invalidPercent": "请输入 0 到 {max} 之间的有效百分比。",
       "broadcastFailed": "交易失败，请检查私钥后重试。"
     },
+    "permissions": {
+      "pageTitle": "密钥与权限",
+      "intro1": "密码或密钥使用时间越长，安全隐患就越高。因此 Steem 采用等级制密钥系统来保证您的账户安全。您将分别获得不同权限的 Steem 密钥。例如「发帖密钥」用于安全要求较低的社交操作；「活跃密钥」用于钱包相关操作，需要更谨慎保管。",
+      "intro2": "请记录下方您的 Steem 密钥。建议使用密码管理软件（如 1Password、LastPass），或用离线方式安全保存（如纸质备份或 U 盘文件）。",
+      "learnMore": "了解更多",
+      "learnMoreLink": "理解私钥（第一部分）",
+      "print": "打印",
+      "loadError": "加载账户密钥失败。",
+      "reveal": "显示",
+      "revealLoginHint": "使用私钥或主密码登录以显示与本账户匹配的密钥。",
+      "showQr": "显示二维码",
+      "qrPublicTitle": "公开 {type} 密钥",
+      "qrPrivateTitle": "私有 {type} 密钥",
+      "publicKeyTitle": "公开 {type} 密钥",
+      "privateKeyMasked": "私钥",
+      "authTypePosting": "发帖",
+      "authTypeActive": "活跃",
+      "authTypeOwner": "拥有者",
+      "authTypeMemo": "备注",
+      "postingTab": "发帖密钥",
+      "activeTab": "活跃密钥",
+      "ownerTab": "拥有者密钥",
+      "memoTab": "备注密钥",
+      "publicTab": "公钥",
+      "postingPrivateTitle": "您的私人发帖密钥",
+      "activePrivateTitle": "您的私人活跃密钥",
+      "ownerPrivateTitle": "您的私人拥有者密钥",
+      "memoPrivateTitle": "您的私人备注密钥",
+      "postingPermissionsTitle": "发帖密钥权限",
+      "postingPermissionsIntro": "您的发帖密钥可用于：",
+      "postingPermissionItems": [
+        "发布帖子或评论",
+        "编辑帖子或评论",
+        "投支持或反对票",
+        "分享内容",
+        "关注用户",
+        "关闭通知"
+      ],
+      "activePermissionsTitle": "活跃密钥权限",
+      "activePermissionsIntro": "您的活跃密钥可用于：",
+      "activePermissionItems": [
+        "代币转账",
+        "Power up 或 power down STEEM",
+        "SBD 转换",
+        "为见证人投票",
+        "在交易所下单",
+        "部分个人档案修改",
+        "发布见证人喂价",
+        "创建新用户"
+      ],
+      "ownerPermissionsTitle": "拥有者密钥权限",
+      "ownerPermissionsIntro": "您的拥有者密钥可用于：",
+      "ownerPermissionItems": [
+        "重置拥有者、活跃及发帖密钥",
+        "找回您的账号",
+        "拒绝投票权"
+      ],
+      "memoPermissionsTitle": "备注密钥权限",
+      "memoPermissionsIntro": "您的备注密钥可用于：",
+      "memoPermissionItems": [
+        "发送加密消息",
+        "查看加密消息"
+      ],
+      "posting": {
+        "desc1": "该密钥用于发帖、评论和投票等社交操作。权限有限，不适用于资金操作；他人获得该密钥也不会影响您的财产。",
+        "desc2": "可用于登录 Steemit、Busy、eSteem 等 Steem 社交平台。请妥善保管。"
+      },
+      "active": {
+        "desc1": "此密钥拥有转账、代币交易等资金操作权限。",
+        "desc2": "执行钱包相关操作时系统会提示使用活跃密钥验证。请仅在信任的应用中输入；拥有此密钥者可提取您的代币。请妥善保管。"
+      },
+      "owner": {
+        "desc": "拥有者密钥用于修改其他密钥，可恢复账户或修改其他密钥。这是最重要的密钥，应离线安全存储。"
+      },
+      "memo": {
+        "desc": "备注密钥用于对区块链上的私人消息加密和解密。解密私人消息时应使用所需授权最少的密钥，即备注密钥。"
+      },
+      "public": {
+        "desc1": "每个 Steem 密钥都有公钥和私钥。公钥与用户名关联，可用于查询链上交易。登录 Steemit.com 不需要公钥，也无需特意保存。",
+        "desc2": "在 SteemDB 查看此账户的公钥信息（「授权」模块）："
+      }
+    },
     "convertSbd": {
       "title": "将 SBD 转为 STEEM",
       "dialogDescription": "按中位价请求将 SBD 转为 STEEM。",

--- a/src/lib/wallet/account-keys.test.ts
+++ b/src/lib/wallet/account-keys.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getPublicKeysForAuth,
+  wifForPublicKey,
+  type AuthRoleKeys,
+} from '@/lib/wallet/account-keys';
+import type { SteemAccount } from '@/lib/steem/types';
+
+const sampleAccount = {
+  name: 'alice',
+  memo_key: 'STMmemoPub',
+  posting: { key_auths: [['STMpostPub', 1]], account_auths: [], weight_threshold: 1 },
+  active: { key_auths: [['STMacPub', 1]], account_auths: [], weight_threshold: 1 },
+  owner: { key_auths: [['STMownPub', 1]], account_auths: [], weight_threshold: 1 },
+} as unknown as SteemAccount;
+
+describe('getPublicKeysForAuth', () => {
+  it('returns memo_key for memo', () => {
+    expect(getPublicKeysForAuth(sampleAccount, 'memo')).toEqual(['STMmemoPub']);
+  });
+
+  it('returns key_auths public keys for posting', () => {
+    expect(getPublicKeysForAuth(sampleAccount, 'posting')).toEqual(['STMpostPub']);
+  });
+});
+
+describe('wifForPublicKey', () => {
+  it('returns undefined when no keys match', () => {
+    const keys: AuthRoleKeys = {
+      ownerKey: null,
+      activeKey: null,
+      postingKey: null,
+      memoKey: null,
+    };
+    expect(wifForPublicKey('STMunknown', keys)).toBeUndefined();
+  });
+});

--- a/src/lib/wallet/account-keys.ts
+++ b/src/lib/wallet/account-keys.ts
@@ -1,0 +1,57 @@
+import { SteemSigner } from '@/lib/steem/client';
+import type { SteemAccount } from '@/lib/steem/types';
+
+export type AccountAuthType = 'posting' | 'active' | 'owner' | 'memo';
+
+export interface AuthRoleKeys {
+  ownerKey: string | null;
+  activeKey: string | null;
+  postingKey: string | null;
+  memoKey: string | null;
+}
+
+/** Public keys for an authority type (memo is a single key). */
+export function getPublicKeysForAuth(
+  account: SteemAccount,
+  authType: AccountAuthType
+): string[] {
+  if (authType === 'memo') {
+    return account.memo_key ? [account.memo_key] : [];
+  }
+  const auths = account[authType]?.key_auths;
+  if (!Array.isArray(auths)) return [];
+  return auths.map(([pub]) => pub).filter((pub): pub is string => Boolean(pub));
+}
+
+/** WIF that matches `pubkey`, if any role key in memory corresponds. */
+export function wifForPublicKey(pubkey: string, keys: AuthRoleKeys): string | undefined {
+  const candidates = [keys.ownerKey, keys.activeKey, keys.postingKey, keys.memoKey];
+  for (const wif of candidates) {
+    if (!wif) continue;
+    try {
+      if (SteemSigner.privateKeyToPublicKey(wif) === pubkey) return wif;
+    } catch {
+      // ignore invalid WIF
+    }
+  }
+  return undefined;
+}
+
+/** Role-specific private key from Redux (may not match account pubkey until login). */
+export function privateKeyForAuthType(
+  authType: AccountAuthType,
+  keys: AuthRoleKeys
+): string | null {
+  switch (authType) {
+    case 'owner':
+      return keys.ownerKey;
+    case 'active':
+      return keys.activeKey;
+    case 'posting':
+      return keys.postingKey;
+    case 'memo':
+      return keys.memoKey;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the `/@username/permissions` placeholder with a full Keys & Permissions experience aligned with wallet-legacy `UserKeys`.
- Add posting/active/owner/memo/public tabs, public key display, permission lists, Reveal (login dialog), QR codes (`react-qr-code`), and print when a private key is visible.
- Add `wallet.permissions` i18n (en/zh/es), account key helpers, and lazy-loaded `PermissionsSection`.

## Test plan

- [ ] Open `/@{your-username}/permissions` while logged in as that account; verify all five tabs render and public keys match chain data.
- [ ] Click **Reveal** without keys in memory; complete login; confirm matching WIF appears for the role you authenticated with.
- [ ] Open QR dialog for public and private keys; confirm codes scan correctly.
- [ ] With a revealed WIF, use **Print** and confirm nav/chrome is hidden (`.no-print`).
- [ ] Visit another user’s permissions URL; confirm public keys show and Reveal prompts login (no foreign WIF without auth).
- [ ] `pnpm verify` passes locally (CI should match).