### PR TITLE
fix(auth): memoize useAuthRoleKeys selector

### DIFF
--- a/src/hooks/use-auth-role-keys.ts
+++ b/src/hooks/use-auth-role-keys.ts
@@ -1,15 +1,27 @@
 'use client';
 
+import { createSelector } from '@reduxjs/toolkit';
 import { useSelector } from 'react-redux';
 import type { RootState } from '@/lib/store';
 import type { AuthRoleKeys } from '@/lib/wallet/account-keys';
 
+const selectAuthRoleKeys = createSelector(
+  [
+    (state: RootState) => state.auth.username,
+    (state: RootState) => state.auth.ownerKey,
+    (state: RootState) => state.auth.activeKey,
+    (state: RootState) => state.auth.postingKey,
+    (state: RootState) => state.auth.memoKey,
+  ],
+  (username, ownerKey, activeKey, postingKey, memoKey): AuthRoleKeys & { username: string | null } => ({
+    username,
+    ownerKey,
+    activeKey,
+    postingKey,
+    memoKey,
+  })
+);
+
 export function useAuthRoleKeys(): AuthRoleKeys & { username: string | null } {
-  return useSelector((state: RootState) => ({
-    username: state.auth.username,
-    ownerKey: state.auth.ownerKey,
-    activeKey: state.auth.activeKey,
-    postingKey: state.auth.postingKey,
-    memoKey: state.auth.memoKey,
-  }));
+  return useSelector(selectAuthRoleKeys);
 }


### PR DESCRIPTION
## Summary

- Memoize `useAuthRoleKeys` with `createSelector` so `useSelector` returns a stable object reference when auth keys are unchanged.
- Fixes React-Redux dev warning on the permissions page that compared two selector results and printed WIFs to the **browser** console (not the server).

## Context

The previous inline selector created a new object on every call. In development, React-Redux logs `selected` / `selected2` when references differ, which exposed in-memory keys in DevTools. Keys were never sent to the API; this only affected local dev console output.

## Test plan

- [x] `pnpm verify` passes
- [ ] Open `/@{username}/permissions` while logged in; confirm no `useAuthRoleKeys` selector warning in the browser console
- [ ] Reveal key flow still works after login