### PR TITLE
Fix header logout: show Login/Sign Up and reuse login dialog

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,15 +1,14 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useSyncExternalStore } from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from '@/lib/store';
-import { getRememberedDeviceUsername } from '@/lib/auth/browser-storage';
+import { useAuth } from '@/hooks/use-auth';
 import { SteemLogo } from './steem-logo';
 import { useTheme } from '@/lib/theme';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import { LoginForm } from '@/components/auth/login-form';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,6 +16,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Menu, Wallet, Key, Settings, LogOut, Sun, Moon, Monitor } from 'lucide-react';
@@ -29,34 +35,30 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
   const t = useTranslations('auth');
   const router = useRouter();
   const { theme, cycleTheme } = useTheme();
-  const reduxUsername = useSelector((state: RootState) => state.auth.username);
+  const { username, isAuthenticated, logout } = useAuth();
+  const [loginOpen, setLoginOpen] = useState(false);
 
-  // useSyncExternalStore is used here purely as an SSR-safe initializer:
-  // getServerSnapshot returns null so server and hydration renders match,
-  // then React detects the post-hydration snapshot diff and re-renders once
-  // to show the avatar. The subscribe is intentionally a no-op — ongoing
-  // login state is owned by Redux; this value is only meaningful at mount.
-  const rememberedUsername = useSyncExternalStore(
-    () => () => {},
-    () => getRememberedDeviceUsername(),
-    () => null
-  );
-
-  const username = reduxUsername ?? rememberedUsername;
-  const isLoggedIn = !!username;
   const signupUrl = process.env.NEXT_PUBLIC_SIGNUP_URL ?? 'https://signup.steemit.com';
 
   const handleLogout = async () => {
     try {
-      await fetch('/api/auth/logout', { method: 'POST' });
+      await logout();
       router.push('/');
     } catch (error) {
       console.error('Logout error:', error);
     }
   };
 
-  const themeIcon = theme === 'dark' ? <Moon data-icon="inline-start" /> : theme === 'light' ? <Sun data-icon="inline-start" /> : <Monitor data-icon="inline-start" />;
-  const themeLabel = theme === 'dark' ? 'Dark Mode' : theme === 'light' ? 'Light Mode' : 'Original Mode';
+  const themeIcon =
+    theme === 'dark' ? (
+      <Moon data-icon="inline-start" />
+    ) : theme === 'light' ? (
+      <Sun data-icon="inline-start" />
+    ) : (
+      <Monitor data-icon="inline-start" />
+    );
+  const themeLabel =
+    theme === 'dark' ? 'Dark Mode' : theme === 'light' ? 'Light Mode' : 'Original Mode';
 
   return (
     <header
@@ -65,7 +67,6 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
       )}
     >
       <nav className="flex h-16 items-center px-4 md:px-6">
-        {/* Logo - Left */}
         <div className="flex-shrink-0">
           <Link
             href="/"
@@ -75,31 +76,26 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
           </Link>
         </div>
 
-        {/* Right Side */}
         <div className="ml-auto flex h-16 items-center gap-2 md:gap-4">
-          {/* Not Logged In: Login + Sign Up */}
-          {!isLoggedIn && (
-            <div className="hidden md:flex items-center gap-4">
-              <Link
-                href="/login"
-                className="text-base font-medium transition-colors duration-200 hover:text-accent-foreground"
+          {!isAuthenticated && (
+            <div className="hidden items-center gap-4 md:flex">
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-base font-medium"
+                onClick={() => setLoginOpen(true)}
               >
                 {t('login')}
-              </Link>
+              </Button>
               <Button asChild>
-                <a
-                  href={signupUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a href={signupUrl} target="_blank" rel="noopener noreferrer">
                   {t('signUp')}
                 </a>
               </Button>
             </div>
           )}
 
-          {/* Logged In: User Avatar Dropdown */}
-          {isLoggedIn && (
+          {isAuthenticated && username && (
             <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon-lg" className="rounded-full">
@@ -108,8 +104,8 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
                       src={`https://steemitimages.com/u/${username}/avatar`}
                       alt={username}
                     />
-                    <AvatarFallback className="bg-primary text-primary-foreground font-bold text-sm">
-                      {username?.charAt(0).toUpperCase()}
+                    <AvatarFallback className="bg-primary text-primary-foreground text-sm font-bold">
+                      {username.charAt(0).toUpperCase()}
                     </AvatarFallback>
                   </Avatar>
                 </Button>
@@ -140,13 +136,12 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleLogout} className="cursor-pointer">
                   <LogOut data-icon="inline-start" />
-                  <span>Logout</span>
+                  <span>{t('logout')}</span>
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           )}
 
-          {/* Hamburger Menu */}
           <Button
             variant="ghost"
             size="icon"
@@ -157,6 +152,16 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
           </Button>
         </div>
       </nav>
+
+      <Dialog open={loginOpen} onOpenChange={setLoginOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t('login')}</DialogTitle>
+            <DialogDescription className="sr-only">{t('login')}</DialogDescription>
+          </DialogHeader>
+          <LoginForm embedded onLoginSuccess={() => setLoginOpen(false)} />
+        </DialogContent>
+      </Dialog>
     </header>
   );
 }

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -3,6 +3,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import type { RootState } from '@/lib/store';
+import { clearRememberedDeviceAuth } from '@/lib/auth/browser-storage';
 import { setCredentials, logout as authLogout } from '@/lib/store/slices/auth';
 import { SteemSigner, apiClient } from '@/lib/steem/client';
 
@@ -143,8 +144,8 @@ export function useAuth(): UseAuthReturn {
     } catch {
       // Ignore error
     } finally {
-      // Clear local state
       dispatch(authLogout());
+      clearRememberedDeviceAuth();
     }
   };
 

--- a/src/lib/auth/browser-storage.ts
+++ b/src/lib/auth/browser-storage.ts
@@ -21,6 +21,22 @@ export function clearRememberedPostingKey(): void {
   }
 }
 
+/** Remove saved username from this device (e.g. on logout). */
+export function clearRememberedDeviceUsername(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(REMEMBERED_USERNAME_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Clear all device-persisted login convenience data. */
+export function clearRememberedDeviceAuth(): void {
+  clearRememberedDeviceUsername();
+  clearRememberedPostingKey();
+}
+
 export function getRememberedDeviceUsername(): string | null {
   if (typeof window === 'undefined') return null;
   try {

--- a/tests/unit/browser-storage.test.ts
+++ b/tests/unit/browser-storage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  REMEMBERED_POSTING_KEY_KEY,
+  REMEMBERED_USERNAME_KEY,
+  clearRememberedDeviceAuth,
+  getRememberedDeviceUsername,
+} from '@/lib/auth/browser-storage';
+
+describe('browser-storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('clearRememberedDeviceAuth removes username and posting key', () => {
+    localStorage.setItem(REMEMBERED_USERNAME_KEY, 'alice');
+    localStorage.setItem(REMEMBERED_POSTING_KEY_KEY, '5Jtest');
+
+    clearRememberedDeviceAuth();
+
+    expect(getRememberedDeviceUsername()).toBeNull();
+    expect(localStorage.getItem(REMEMBERED_POSTING_KEY_KEY)).toBeNull();
+  });
+});

--- a/tests/unit/use-auth.test.tsx
+++ b/tests/unit/use-auth.test.tsx
@@ -8,6 +8,10 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { useAuth, useRequireAuth, usePrivateKey } from '@/hooks/use-auth';
 import authReducer from '@/lib/store/slices/auth';
+import {
+  REMEMBERED_POSTING_KEY_KEY,
+  REMEMBERED_USERNAME_KEY,
+} from '@/lib/auth/browser-storage';
 
 // Mock SteemSigner and apiClient - factory function to avoid hoisting issues
 vi.mock('@/lib/steem/client', () => {
@@ -59,7 +63,7 @@ describe('useAuth Hook', () => {
 
   beforeEach(() => {
     mockStore = createTestStore();
-
+    localStorage.clear();
     vi.clearAllMocks();
   });
 
@@ -180,7 +184,9 @@ describe('useAuth Hook', () => {
 
   describe('logout', () => {
     it('should clear auth state on logout', async () => {
-      // Set up logged in state
+      localStorage.setItem(REMEMBERED_USERNAME_KEY, 'testuser');
+      localStorage.setItem(REMEMBERED_POSTING_KEY_KEY, '5Jtest');
+
       mockStore.dispatch({
         type: 'auth/setCredentials',
         payload: {
@@ -201,6 +207,8 @@ describe('useAuth Hook', () => {
       expect(mockStore.getState().auth.username).toBeNull();
       expect(mockStore.getState().auth.isAuthenticated).toBe(false);
       expect(mockStore.getState().auth.privateKey).toBeNull();
+      expect(localStorage.getItem(REMEMBERED_USERNAME_KEY)).toBeNull();
+      expect(localStorage.getItem(REMEMBERED_POSTING_KEY_KEY)).toBeNull();
     });
 
     it('should clear auth state even if server logout fails', async () => {


### PR DESCRIPTION
## Summary

- After logout, the header no longer treats a remembered device username as logged-in, so the avatar is hidden and Login / Sign Up appear again.
- Logout clears Redux session, calls the logout API, and removes device-persisted username/posting key.
- Login in the header opens the same embedded `LoginForm` dialog used elsewhere instead of linking to `/login`; Sign Up still opens the signup URL in a new tab.

## Test plan

- [ ] Log in, open the avatar menu, and log out — confirm Login and Sign Up show on desktop (md+) and the avatar is gone.
- [ ] Click Login in the header — login dialog opens, successful login closes the dialog and shows the avatar.
- [ ] Click Sign Up — signup site opens in a new tab only.
- [ ] Log out again and confirm local remembered username is cleared (home page should not auto-redirect to transfers).