### PR TITLE
fix(docker): copy pnpm-workspace.yaml for pnpm 11 allowBuilds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ RUN apk add --no-cache libc6-compat python3 make g++
 # Enable pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+# Copy package files (pnpm-workspace.yaml required for pnpm 11 allowBuilds)
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies with frozen lockfile for reproducible builds
 RUN pnpm install --frozen-lockfile --prod=false


### PR DESCRIPTION
## Summary
- Copy `pnpm-workspace.yaml` into the production Docker build (`docker/Dockerfile`) so pnpm 11 `allowBuilds` is applied during `pnpm install`.
- Fixes Docker image builds failing with `ERR_PNPM_IGNORED_BUILDS` when packaging for EB.

## Test plan
- [ ] `docker build -f docker/Dockerfile -t steemit/wallet:test .` completes successfully
- [ ] `pnpm install` inside the builder stage no longer reports ignored build scripts for `@swc/core`, `esbuild`, etc.