### PR TITLE
fix(recovery): roll back confirm record to 'confirmed' on failure

### DIFF
--- a/src/app/api/recovery/confirm/route.ts
+++ b/src/app/api/recovery/confirm/route.ts
@@ -64,6 +64,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Track whether the CAS claim succeeded so we can roll it back on failure.
+  let claimed = false;
+
   try {
     // Step 1: Atomically claim the record by setting status to 'processing'.
     // This prevents TOCTOU races — only one request will win the CAS.
@@ -86,6 +89,7 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    claimed = true;
 
     // Step 1b: Cross-validate old_owner_key against the DB record.
     // This ensures the client-submitted key matches the original request.
@@ -94,6 +98,7 @@ export async function POST(request: NextRequest) {
       columns: { id: true, ownerKey: true },
     });
     if (!record || (record.ownerKey && record.ownerKey !== body.old_owner_key)) {
+      await rollbackToConfirmed(db, body.code, body.account_name);
       return NextResponse.json(
         { status: 'error', error: 'Owner key mismatch' },
         { status: 400 }
@@ -101,7 +106,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 2: Call kingdom.recovery_account (broadcasts request_account_recovery on-chain).
-    // If this fails, the record stays in 'processing' and won't be re-processed.
     const { SteemService } = await import('@/lib/steem/server');
 
     // Preflight: the recovery-signing key (CONVEYOR_POSTING_WIF) is a
@@ -110,6 +114,7 @@ export async function POST(request: NextRequest) {
     const conveyorError = SteemService.validateConveyorConfig();
     if (conveyorError) {
       console.error('Recovery confirm blocked:', conveyorError);
+      await rollbackToConfirmed(db, body.code, body.account_name);
       return NextResponse.json(
         { status: 'error', error: 'Recovery service unavailable' },
         { status: 503 }
@@ -140,9 +145,38 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ status: 'ok' });
   } catch (err) {
     console.error('Recovery confirm failed:', err);
+    // Roll back the CAS claim so the user can retry. Without this the record
+    // would be stuck in 'processing' forever (no other path resets it), and a
+    // single transient RPC error would permanently brick the recovery.
+    if (claimed) {
+      await rollbackToConfirmed(db, body.code, body.account_name).catch(() => {});
+    }
     return NextResponse.json(
       { status: 'error', error: 'Internal server error' },
       { status: 500 }
     );
   }
+}
+
+/**
+ * Revert a recovery record from 'processing' back to 'confirmed' so the user
+ * can retry. Best-effort: swallows errors (the response error is already
+ * decided by the caller). Only resets records still in 'processing' to avoid
+ * clobbering a concurrent success.
+ */
+async function rollbackToConfirmed(
+  db: NonNullable<ReturnType<typeof getDb>>,
+  code: string,
+  accountName: string
+): Promise<void> {
+  await db
+    .update(arecs)
+    .set({ status: 'confirmed' })
+    .where(
+      and(
+        eq(arecs.validationCode, code),
+        eq(arecs.accountName, accountName),
+        eq(arecs.status, 'processing')
+      )
+    );
 }

--- a/tests/unit/recovery-confirm-route.test.ts
+++ b/tests/unit/recovery-confirm-route.test.ts
@@ -50,18 +50,22 @@ function makeRequest(body: Record<string, unknown>): NextRequest {
   });
 }
 
-function setupUpdateMocks(firstResult: unknown, secondResult?: unknown) {
-  const chain1: Record<string, ReturnType<typeof vi.fn>> = {};
-  chain1.where = vi.fn().mockResolvedValue(firstResult);
-  chain1.set = vi.fn().mockReturnValue({ where: chain1.where });
+function setupUpdateMocks(firstResult: unknown, secondResult?: unknown, thirdResult?: unknown) {
+  const makeChain = (result: unknown) => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+    chain.where = vi.fn().mockResolvedValue(result ?? undefined);
+    chain.set = vi.fn().mockReturnValue({ where: chain.where });
+    return chain;
+  };
 
-  const chain2: Record<string, ReturnType<typeof vi.fn>> = {};
-  chain2.where = vi.fn().mockResolvedValue(secondResult ?? undefined);
-  chain2.set = vi.fn().mockReturnValue({ where: chain2.where });
+  const chain1 = makeChain(firstResult);
+  const chain2 = makeChain(secondResult);
+  const chain3 = makeChain(thirdResult);
 
   mockUpdateFn = vi.fn()
     .mockReturnValueOnce({ set: chain1.set })
-    .mockReturnValueOnce({ set: chain2.set });
+    .mockReturnValueOnce({ set: chain2.set })
+    .mockReturnValueOnce({ set: chain3.set });
 }
 
 describe('POST /api/recovery/confirm', () => {
@@ -176,6 +180,9 @@ describe('POST /api/recovery/confirm', () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toBe('Owner key mismatch');
+    // Rollback: the record is reverted from 'processing' to 'confirmed' so the
+    // user can retry. 3 update calls: CAS claim → findFirst → rollback.
+    expect(mockUpdateFn).toHaveBeenCalledTimes(2);
   });
 
   it('allows confirm when DB ownerKey is null (legacy records)', async () => {
@@ -213,6 +220,39 @@ describe('POST /api/recovery/confirm', () => {
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.status).toBe('error');
+  });
+
+  it('rolls back to confirmed when requestAccountRecovery throws (retryable)', async () => {
+    // Regression test: without rollback, a transient RPC error leaves the
+    // record stuck in 'processing' forever — the user can never retry.
+    setupUpdateMocks({ affectedRows: 1 });
+
+    const { SteemService } = await import('@/lib/steem/server');
+    vi.mocked(SteemService.requestAccountRecovery).mockRejectedValueOnce(
+      new Error('Kingdom unreachable')
+    );
+
+    const req = makeRequest(validPayload);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    // CAS claim (1st) → rollback in catch (2nd). Success close never runs.
+    expect(mockUpdateFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('rolls back to confirmed when conveyor config is missing (503 retryable)', async () => {
+    setupUpdateMocks({ affectedRows: 1 });
+
+    const { SteemService } = await import('@/lib/steem/server');
+    vi.mocked(SteemService.validateConveyorConfig).mockReturnValueOnce(
+      'CONVEYOR_POSTING_WIF missing'
+    );
+
+    const req = makeRequest(validPayload);
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    // CAS claim (1st) → rollback (2nd). User can retry.
+    expect(mockUpdateFn).toHaveBeenCalledTimes(2);
   });
 
   it('returns 500 when database update throws', async () => {


### PR DESCRIPTION
## Summary

Fixes audit V2 finding #1 (High): the `recovery/confirm` route's CAS claim sets `status = 'processing'`, but only the success path transitions to `'closed'`. Every failure path left the record permanently stuck in `'processing'` — the user could never retry, and the subsequent `recover-account` broadcast (which requires `status = 'closed'`) was wedged. A single transient Steem RPC error would permanently brick a recovery request.

## Changes

- **`src/app/api/recovery/confirm/route.ts`**: add `rollbackToConfirmed()` helper that resets `'processing' → 'confirmed'` (CAS-guarded on `status = 'processing'` to avoid clobbering a concurrent success). Call it on every failure path after the CAS claim:
  - owner-key mismatch (400)
  - conveyor config missing (503)
  - `requestAccountRecovery` RPC error / any catch (500; best-effort)
- **`tests/unit/recovery-confirm-route.test.ts`**: add rollback regression tests for the RPC-error and conveyor-missing paths; extend `setupUpdateMocks` to support the third update chain (rollback).

## Root cause

The CAS at the top of the try-block atomically claims the record (`confirmed → processing`) to prevent TOCTOU races. But the original code's comment even admitted: *"If this fails, the record stays in 'processing' and won't be re-processed."* — with no rollback or janitor to reset it.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 467 passed (includes 2 new rollback regression tests)