### PR TITLE
fix(security): fall back to x-real-ip when TRUST_PROXY_COUNT is unset

### DIFF
--- a/src/lib/middleware/rate-limit.ts
+++ b/src/lib/middleware/rate-limit.ts
@@ -7,7 +7,8 @@
 // - Client IP resolution is proxy-aware: when the app sits behind a trusted
 //   proxy (ELB/OpenResty) set TRUST_PROXY_COUNT to the number of trusted hops,
 //   so a spoofable client-supplied X-Forwarded-For cannot reset the limiter.
-//   When TRUST_PROXY_COUNT is unset we use the socket peer (no header trust).
+//   When TRUST_PROXY_COUNT is unset we fall back to x-real-ip (set by the
+//   reverse proxy, which overwrites any client value), then 'unknown'.
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getRedis, redisKey } from '@/lib/cache/redis';
@@ -36,7 +37,7 @@ if (typeof setInterval !== 'undefined') {
   setInterval(cleanupExpiredEntries, 5 * 60 * 1000);
 }
 
-// Parse the trusted-hops count from env (undefined => do not trust headers).
+// Parse the trusted-hops count from env (undefined => do not trust XFF).
 function getTrustedProxyCount(): number | null {
   const raw = process.env.TRUST_PROXY_COUNT;
   if (raw === undefined || raw === '') return null;
@@ -44,11 +45,20 @@ function getTrustedProxyCount(): number | null {
   return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
+let warnedMissingProxyConfig = false;
+
 /**
- * Resolve the client IP. Proxy-aware: when TRUST_PROXY_COUNT is set, read the
- * Nth-from-right entry of X-Forwarded-For (the hop our trusted proxy appended).
- * Without it we rely on the socket peer and ignore client headers entirely, so
- * a spoofed X-Forwarded-For cannot bypass rate limiting.
+ * Resolve the client IP.
+ *
+ * Priority:
+ * 1. TRUST_PROXY_COUNT set: read the Nth-from-right entry of X-Forwarded-For
+ *    (the hop our trusted proxy appended). This is the most spoof-resistant.
+ * 2. TRUST_PROXY_COUNT unset: fall back to x-real-ip. The reverse proxy
+ *    (OpenResty/ELB) sets this header by OVERWRITING any client value, so it
+ *    is far harder to spoof than X-Forwarded-For (which is append-only). This
+ *    prevents the rate-limit bucket from collapsing to a single 'unknown' key
+ *    when an operator forgets to set TRUST_PROXY_COUNT.
+ * 3. Neither available: 'unknown' (all clients share one bucket — degraded).
  */
 function getClientIP(request: NextRequest): string {
   const trustedHops = getTrustedProxyCount();
@@ -64,9 +74,22 @@ function getClientIP(request: NextRequest): string {
       if (parts.length > 0) return parts[parts.length - 1]!;
     }
   }
-  // No trusted-proxy config: prefer the Next.js peer IP if present, else the
-  // raw x-real-ip only when behind a proxy we trust. Fall back to 'unknown'.
-  // (x-real-ip / cf-connecting-ip are intentionally not trusted unilaterally.)
+
+  // No TRUST_PROXY_COUNT: fall back to x-real-ip (set by the reverse proxy,
+  // which overwrites client-supplied values). This prevents the limiter from
+  // collapsing all clients into a single 'unknown' bucket.
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) return realIp.trim();
+
+  // Truly nothing to go on. Warn once in production so operators notice.
+  if (!warnedMissingProxyConfig && process.env.NODE_ENV === 'production') {
+    console.warn(
+      'rate-limit: TRUST_PROXY_COUNT is not set and x-real-ip is absent — ' +
+        'all clients share a single rate-limit bucket. Set TRUST_PROXY_COUNT ' +
+        'or ensure the reverse proxy sets x-real-ip.'
+    );
+    warnedMissingProxyConfig = true;
+  }
   return 'unknown';
 }
 

--- a/tests/unit/rate-limit-proxy.test.ts
+++ b/tests/unit/rate-limit-proxy.test.ts
@@ -50,9 +50,27 @@ describe('rate-limit proxy-aware client IP (TRUST_PROXY_COUNT)', () => {
     expect(r2!.status).toBe(429);
   });
 
-  it('falls back to "unknown" when TRUST_PROXY_COUNT is unset (ignores XFF)', async () => {
+  it('falls back to x-real-ip when TRUST_PROXY_COUNT is unset', async () => {
     delete process.env.TRUST_PROXY_COUNT;
-    // Two requests with different XFF but both resolve to "unknown" → shared bucket.
+    // Without TRUST_PROXY_COUNT, x-real-ip (set by the reverse proxy) is used.
+    // Two requests from different x-real-ip get separate buckets.
+    const r1 = await rateLimit(
+      makeReq({ 'x-real-ip': '1.1.1.1' }),
+      'broadcast',
+      { maxRequests: 1, windowSeconds: 60 }
+    );
+    expect(r1).toBeNull(); // allowed
+    const r2 = await rateLimit(
+      makeReq({ 'x-real-ip': '2.2.2.2' }),
+      'broadcast',
+      { maxRequests: 1, windowSeconds: 60 }
+    );
+    expect(r2).toBeNull(); // also allowed — different IP, different bucket
+  });
+
+  it('falls back to "unknown" when neither TRUST_PROXY_COUNT nor x-real-ip is present', async () => {
+    delete process.env.TRUST_PROXY_COUNT;
+    // No x-real-ip, no TRUST_PROXY_COUNT → all collapse to 'unknown'.
     await rateLimit(makeReq({ 'x-forwarded-for': '1.1.1.1' }), 'broadcast', {
       maxRequests: 1,
       windowSeconds: 60,


### PR DESCRIPTION
## Summary

Fixes audit V2 finding #3 (High): when `TRUST_PROXY_COUNT` is not configured, `getClientIP()` returned `'unknown'` for every request, collapsing all clients into a single rate-limit bucket. One abuser could exhaust the shared quota and DoS the endpoint for all legitimate users. The comment claimed it fell back to "socket peer" but Next.js route handlers do not expose a synchronous socket peer.

## Changes

**`src/lib/middleware/rate-limit.ts`** — new three-tier IP resolution in `getClientIP()`:
1. `TRUST_PROXY_COUNT` set: Nth-from-right XFF entry (most spoof-resistant) — unchanged.
2. `TRUST_PROXY_COUNT` unset: **fall back to `x-real-ip`**. The reverse proxy (OpenResty/ELB) sets this by **overwriting** client-supplied values, so it is far harder to spoof than the append-only `X-Forwarded-For`. This prevents bucket collapse when an operator forgets `TRUST_PROXY_COUNT`, as long as the reverse proxy sets `x-real-ip` (standard practice).
3. Neither present: `'unknown'` + a one-time production warning log (so operators notice).

**`tests/unit/rate-limit-proxy.test.ts`:**
- New test: `x-real-ip` fallback gives different IPs separate buckets.
- Split the old "unknown" test into with/without `x-real-ip` cases.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 471 passed