### PR TITLE
fix(security): scope signature verification to the operation's required authority

### DIFF
--- a/src/app/api/broadcast/account-update/route.ts
+++ b/src/app/api/broadcast/account-update/route.ts
@@ -48,9 +48,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Cryptographically verify the signature belongs to the claimed account
-    // (requires @steemit/steem-js >=1.0.20).
-    const verifyResult = await SteemService.verifyTransactionForUsername(signedTx, username);
+    // Cryptographically verify the signature belongs to the claimed account's
+    // OWNER authority (account_update requires owner). (requires @steemit/steem-js >=1.0.20)
+    const verifyResult = await SteemService.verifyTransactionForUsername(signedTx, username, 'owner');
     if (!verifyResult.ok) {
       return NextResponse.json(
         { error: verifyResult.error ?? 'Transaction verification failed' },

--- a/src/lib/steem/server.ts
+++ b/src/lib/steem/server.ts
@@ -74,6 +74,26 @@ async function withFailover<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /**
+ * Collect the public keys for the specified authority roles of an account.
+ */
+function collectAuthorityKeys(
+  account: SteemAccount,
+  roles: ('owner' | 'active' | 'posting')[]
+): string[] {
+  const keys: string[] = [];
+  for (const role of roles) {
+    const auth = account[role];
+    if (auth?.key_auths) {
+      for (const entry of auth.key_auths) {
+        const pub = Array.isArray(entry) ? entry[0] : undefined;
+        if (typeof pub === 'string') keys.push(pub);
+      }
+    }
+  }
+  return keys;
+}
+
+/**
  * Server-side Steem service
  * Handles all communication with Steem blockchain nodes
  */
@@ -700,33 +720,38 @@ export class SteemService {
    * `steem.auth.verifyTransaction` which reconstructs the real signing digest
    * `sha256(chain_id || serializeTransaction(trx))`.
    *
-   * This closes the audit's Critical #1 gap: the server can now prove the
-   * signer holds a key on the claimed account *before* relaying the broadcast.
-   * We accept any of the account's owner/active/posting/memo public keys, since
-   * different operations require different authorities and the wallet signs with
-   * whichever role key the user provided.
+   * When `requiredAuthority` is provided, only the key set for that authority is
+   * checked (e.g. a `transfer` must be signed by an active key). This prevents a
+   * memo-key-signed transaction from passing relay validation — the chain would
+   * reject it anyway, but checking here avoids relaying doomed transactions and
+   * closes the gap where any account key (including memo) was accepted.
    *
    * Returns true only if: shape is valid AND at least one signature verifies
-   * against one of the account's keys. Returns false (never throws) on any error.
+   * against one of the account's keys (of the required authority). Returns false
+   * (never throws) on any error.
    */
   static verifyTransactionForAccount(
     signedTx: SignedTransaction,
-    account: SteemAccount
+    account: SteemAccount,
+    requiredAuthority?: 'owner' | 'active' | 'posting'
   ): boolean {
     if (!SteemService.validateTransactionShape(signedTx)) return false;
 
     try {
       ensureConfigured();
-      // Collect all public keys on the account across authorities.
-      const ownerKeys = account.owner?.key_auths?.map((k) => k[0]) ?? [];
-      const activeKeys = account.active?.key_auths?.map((k) => k[0]) ?? [];
-      const postingKeys = account.posting?.key_auths?.map((k) => k[0]) ?? [];
-      const memoKey = account.memo_key ? [account.memo_key] : [];
-      const accountKeys = [...ownerKeys, ...activeKeys, ...postingKeys, ...memoKey]
-        .filter((k): k is string => typeof k === 'string' && k.length > 0);
+      // Collect the public keys for the relevant authority/authorities.
+      let accountKeys: string[];
+      if (requiredAuthority) {
+        accountKeys = collectAuthorityKeys(account, [requiredAuthority]);
+      } else {
+        // No authority filter: check all keys (owner/active/posting/memo).
+        accountKeys = collectAuthorityKeys(account, ['owner', 'active', 'posting']);
+        if (account.memo_key) accountKeys = [...accountKeys, account.memo_key];
+      }
+      accountKeys = accountKeys.filter((k) => typeof k === 'string' && k.length > 0);
 
       // verifyTransaction returns true if ANY signature matches the given public
-      // key. We accept the transaction if any of the account's keys verifies it.
+      // key. We accept the transaction if any of the relevant keys verifies it.
       return accountKeys.some((pubKey) =>
         steem.auth.verifyTransaction(
           signedTx as unknown as Record<string, unknown>,
@@ -743,12 +768,15 @@ export class SteemService {
    * account named in the transaction (fetched from chain). Convenience wrapper
    * for broadcast routes that have a `username` but not a pre-fetched account.
    *
+   * When `requiredAuthority` is provided, only that authority's key set is checked.
+   *
    * Returns { ok, error? }. On failure `error` explains whether it was a shape
    * problem, a fetch failure, or a signature mismatch.
    */
   static async verifyTransactionForUsername(
     signedTx: SignedTransaction,
-    username: string
+    username: string,
+    requiredAuthority?: 'owner' | 'active' | 'posting'
   ): Promise<{ ok: boolean; error?: string }> {
     if (!SteemService.validateTransactionShape(signedTx)) {
       return { ok: false, error: 'Invalid transaction format' };
@@ -763,7 +791,7 @@ export class SteemService {
     if (!account) {
       return { ok: false, error: 'Could not verify signer (account not found)' };
     }
-    if (!SteemService.verifyTransactionForAccount(signedTx, account)) {
+    if (!SteemService.verifyTransactionForAccount(signedTx, account, requiredAuthority)) {
       return { ok: false, error: 'Transaction signature does not match account' };
     }
     return { ok: true };

--- a/src/lib/steem/validate-signed-tx-op.ts
+++ b/src/lib/steem/validate-signed-tx-op.ts
@@ -2,6 +2,37 @@ import { NextResponse } from 'next/server';
 import type { SignedTransaction } from './types';
 import { SteemService } from './server';
 
+/** The Steem authority level required to sign an operation. */
+export type RequiredAuthority = 'owner' | 'active' | 'posting';
+
+/**
+ * Map each relayed operation type to the authority required to sign it on-chain.
+ * Used to ensure the signature is checked against the correct key set (e.g. a
+ * `transfer` signed with the memo key is rejected at the relay, not just by the
+ * chain). `memo` is never a valid signing authority for any operation.
+ *
+ * Reference: Steem operation permissions (steem-js / chain consensus).
+ */
+const OP_AUTHORITY: Record<string, RequiredAuthority> = {
+  // active authority
+  transfer: 'active',
+  convert: 'active',
+  limit_order_create: 'active',
+  limit_order_cancel: 'active',
+  delegate_vesting_shares: 'active',
+  withdraw_vesting: 'active',
+  set_withdraw_vesting_route: 'active',
+  account_create: 'active',
+  account_witness_vote: 'active',
+  account_witness_proxy: 'active',
+  create_proposal: 'active',
+  update_proposal_votes: 'active',
+  remove_proposal: 'active',
+  // posting authority
+  vote: 'posting',
+  custom_json: 'posting',
+};
+
 /**
  * Verify that the first operation in a signed transaction has the expected type.
  *
@@ -24,9 +55,24 @@ export function assertSignedTxOpType(
 }
 
 /**
+ * Resolve the on-chain required authority for an operation type. Defaults to
+ * 'active' for unknown ops (a conservative choice — active is the most common
+ * signing authority and memo is never valid).
+ */
+export function getRequiredAuthority(opType: string): RequiredAuthority {
+  return OP_AUTHORITY[opType] ?? 'active';
+}
+
+/**
  * Combined relay validation for broadcast routes: enforces the operation type
  * AND performs real cryptographic signature verification against the claimed
  * account (via @steemit/steem-js >=1.0.20 `verifyTransaction`).
+ *
+ * The signature is checked against only the key set for the operation's required
+ * authority (e.g. a `transfer` must be signed by an active key, not a memo key).
+ * This strengthens defense-in-depth: the chain would also reject a wrong-authority
+ * signature, but checking here avoids relaying doomed transactions and closes the
+ * gap where any account key (including memo) was accepted.
  *
  * Returns a 400/503 NextResponse on failure, or `null` when the transaction is
  * valid and may be relayed. Call this before `broadcastTransaction`.
@@ -47,9 +93,9 @@ export async function validateRelayTransaction(
   }
 
   // 2. Cryptographic signature verification: the transaction must be signed by
-  //    a key belonging to the claimed account. This is the server-side defense
-  //    that closes the audit's Critical #1 gap (previously shape-only).
-  const result = await SteemService.verifyTransactionForUsername(signedTx, username);
+  //    a key of the REQUIRED authority belonging to the claimed account.
+  const requiredAuth = getRequiredAuthority(expectedOp);
+  const result = await SteemService.verifyTransactionForUsername(signedTx, username, requiredAuth);
   if (!result.ok) {
     return NextResponse.json({ error: result.error ?? 'Transaction verification failed' }, { status: 400 });
   }

--- a/tests/unit/verify-transaction.test.ts
+++ b/tests/unit/verify-transaction.test.ts
@@ -94,6 +94,42 @@ describe('SteemService.verifyTransactionForAccount', () => {
     });
     expect(SteemService.verifyTransactionForAccount(makeSignedTx(), makeAccount())).toBe(false);
   });
+
+  it('with requiredAuthority=active: accepts active key, rejects memo/posting key', () => {
+    // Only the active key verifies; posting/memo keys return false.
+    mockVerifyTransaction.mockImplementation((_tx, pubKey) => pubKey === 'STM5Active');
+    expect(
+      SteemService.verifyTransactionForAccount(makeSignedTx(), makeAccount(), 'active')
+    ).toBe(true);
+  });
+
+  it('with requiredAuthority=active: rejects when only memo key verifies', () => {
+    // Simulate: the signature matches the memo key, but NOT the active key.
+    // With authority filtering, memo is excluded → must return false.
+    mockVerifyTransaction.mockImplementation((_tx, pubKey) => pubKey === 'STM5Memo');
+    expect(
+      SteemService.verifyTransactionForAccount(makeSignedTx(), makeAccount(), 'active')
+    ).toBe(false);
+  });
+
+  it('with requiredAuthority=posting: accepts posting key only', () => {
+    mockVerifyTransaction.mockImplementation((_tx, pubKey) => pubKey === 'STM5Posting');
+    expect(
+      SteemService.verifyTransactionForAccount(makeSignedTx(), makeAccount(), 'posting')
+    ).toBe(true);
+  });
+
+  it('with requiredAuthority=owner: accepts owner key only', () => {
+    mockVerifyTransaction.mockImplementation((_tx, pubKey) => pubKey === 'STM5Owner');
+    expect(
+      SteemService.verifyTransactionForAccount(makeSignedTx(), makeAccount(), 'owner')
+    ).toBe(true);
+  });
+
+  it('without requiredAuthority: checks all keys including memo (backwards compat)', () => {
+    mockVerifyTransaction.mockImplementation((_tx, pubKey) => pubKey === 'STM5Memo');
+    expect(SteemService.verifyTransactionForAccount(makeSignedTx(), makeAccount())).toBe(true);
+  });
 });
 
 describe('SteemService.verifyTransactionForUsername', () => {


### PR DESCRIPTION
## Summary

Fixes audit V2 finding #4 (Medium): `verifyTransactionForAccount` accepted ANY of the account's keys (owner/active/posting/memo). A `transfer` signed with the memo key would pass relay validation — the chain rejects it, but the relay already forwarded a doomed transaction, wasting an RPC call and returning a misleading error. This weakens defense-in-depth.

## Changes

**`src/lib/steem/validate-signed-tx-op.ts`:**
- New `OP_AUTHORITY` map: 15 operations → required authority (`active` for 13, `posting` for vote/custom_json).
- New `getRequiredAuthority(opType)` — defaults to `active` for unknown ops (memo is never valid).
- `validateRelayTransaction` now derives the authority from the op type and passes it to verification.

**`src/lib/steem/server.ts`:**
- `verifyTransactionForAccount` / `verifyTransactionForUsername` accept an optional `requiredAuthority` parameter.
- New `collectAuthorityKeys()` helper filters keys by role — memo key is excluded when an authority is specified.
- Backwards-compatible: without `requiredAuthority`, checks all keys (including memo).

**`src/app/api/broadcast/account-update/route.ts`:**
- Explicitly passes `'owner'` (account_update requires owner authority).

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 476 passed (5 new authority-isolation tests)