### PR TITLE
fix(security): audit V2 medium/low — query routes, cache, analytics, client

### DIFF
--- a/src/app/api/query/expiring-vesting-delegations/route.ts
+++ b/src/app/api/query/expiring-vesting-delegations/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
 import { withCache } from '@/lib/cache/server-cache';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Missing account parameter' }, { status: 400 });
     }
 
-    const cacheKey = `cache:query:expiring-vesting-delegations:${account}`;
+    const cacheKey = hashedCacheKey('cache:query:expiring-vesting-delegations', account);
     const result = await withCache(cacheKey, 15, 120, () =>
       SteemService.getExpiringVestingDelegations(account)
     );

--- a/src/app/api/query/history/route.ts
+++ b/src/app/api/query/history/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
 import { getRedis, redisKey } from '@/lib/cache/redis';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 import { isSteemKnownDown } from '@/lib/cache/health-monitor';
 import { normalizeSteemHistoryList, type SteemHistoryItem } from '@/lib/wallet/normalize-history';
 import { WALLET_OP_TYPES } from '@/lib/steem/history-ops';
@@ -38,7 +39,7 @@ export async function GET(request: NextRequest) {
     if (!username) {
       return NextResponse.json({ error: 'Missing username parameter' }, { status: 400 });
     }
-    if (limit < 1 || limit > 100) {
+    if (!Number.isFinite(limit) || limit < 1 || limit > 100) {
       return NextResponse.json({ error: 'Limit must be between 1 and 100' }, { status: 400 });
     }
     if (fromParam !== null && (!Number.isFinite(from) || from < -1)) {
@@ -74,7 +75,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error fetching history:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch history', details: (error as Error).message },
+      { error: 'Failed to fetch history'},
       { status: 500 }
     );
   }
@@ -88,7 +89,7 @@ async function handleFilteredRequest(
   requestedOps: string[]
 ): Promise<NextResponse> {
   const opsKey = [...requestedOps].sort().join('+');
-  const cacheKey = redisKey(`cache:query:history-filtered:${username}:${opsKey}`);
+  const cacheKey = redisKey(hashedCacheKey('cache:query:history-filtered', username, opsKey));
 
   if (await isSteemKnownDown()) {
     const fallback = await getFilteredFallback(cacheKey);
@@ -163,7 +164,7 @@ async function getLegacyFallback(username: string): Promise<unknown[] | null> {
   const redis = getRedis();
   if (!redis) return null;
   try {
-    const raw = await redis.get(redisKey(`cache:query:history-fallback:${username}`));
+    const raw = await redis.get(redisKey(hashedCacheKey('cache:query:history-fallback', username)));
     return raw ? JSON.parse(raw) : null;
   } catch {
     return null;
@@ -175,7 +176,7 @@ async function saveLegacyFallback(username: string, history: unknown): Promise<v
   if (!redis) return;
   try {
     await redis.set(
-      redisKey(`cache:query:history-fallback:${username}`),
+      redisKey(hashedCacheKey('cache:query:history-fallback', username)),
       JSON.stringify(history),
       'EX',
       FALLBACK_TTL

--- a/src/app/api/query/market/route.ts
+++ b/src/app/api/query/market/route.ts
@@ -2,6 +2,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
+import { withCache } from '@/lib/cache/server-cache';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,29 +17,41 @@ export async function GET(request: NextRequest) {
     const username = searchParams.get('username')?.trim().toLowerCase() || undefined;
     const since = searchParams.get('since')?.trim() || undefined;
 
-    const [orderbook, ticker, trades, openOrders] = await Promise.all([
-      SteemService.getMarketOrderBook(),
-      SteemService.getMarketTicker(),
-      since
-        ? SteemService.getMarketTradeHistorySince(since)
-        : SteemService.getMarketRecentTrades(),
-      username ? SteemService.getMarketOpenOrders(username) : Promise.resolve([]),
-    ]);
+    // Cache to avoid fanning out 4 parallel RPCs per request (DoS amplifier).
+    // Short TTL: market data changes frequently; stale-while-revalidate covers
+    // transient failures. User-specific openOrders are included but the key is
+    // scoped by username so no cross-user leakage.
+    const cacheKey = hashedCacheKey('cache:query:market', username ?? '-', since ?? '-');
+    const result = await withCache(cacheKey, 5, 30, async () => {
+      const [orderbook, ticker, trades, openOrders] = await Promise.all([
+        SteemService.getMarketOrderBook(),
+        SteemService.getMarketTicker(),
+        since
+          ? SteemService.getMarketTradeHistorySince(since)
+          : SteemService.getMarketRecentTrades(),
+        username ? SteemService.getMarketOpenOrders(username) : Promise.resolve([]),
+      ]);
 
-    return NextResponse.json({
-      success: true,
-      orderbook,
-      ticker,
-      trades: trades.map((t) => ({
-        ...t,
-        date: t.date.toISOString(),
-      })),
-      openOrders,
+      return {
+        orderbook,
+        ticker,
+        trades: trades.map((t) => ({ ...t, date: t.date.toISOString() })),
+        openOrders,
+      };
     });
+
+    const response = NextResponse.json({
+      success: true,
+      ...result.data,
+      ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
+    });
+    response.headers.set('Cache-Control', 'public, s-maxage=5, stale-while-revalidate=30');
+    if (result.degraded) response.headers.set('X-Degraded', 'true');
+    return response;
   } catch (error) {
     console.error('Market query error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch market data', details: (error as Error).message },
+      { error: 'Failed to fetch market data' },
       { status: 500 }
     );
   }

--- a/src/app/api/query/median-history-price/route.ts
+++ b/src/app/api/query/median-history-price/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('median-history-price query error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch median history price', details: (error as Error).message },
+      { error: 'Failed to fetch median history price'},
       { status: 500 }
     );
   }

--- a/src/app/api/query/proposals/route.ts
+++ b/src/app/api/query/proposals/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { rateLimit } from '@/lib/middleware';
 import { withCache } from '@/lib/cache/server-cache';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 import { SteemService } from '@/lib/steem/server';
 import type { ProposalOrderBy, ProposalOrderDirection, ProposalStatus } from '@/lib/steem/types';
 
@@ -45,14 +46,14 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Limit must be between 1 and 200' }, { status: 400 });
     }
 
-    const cacheKey = [
+    const cacheKey = hashedCacheKey(
       'cache:query:proposals',
       status,
       order,
       direction,
       String(limit),
-      username ? `u:${username}` : 'u:-',
-    ].join(':');
+      username ?? '-'
+    );
 
     const result = await withCache(cacheKey, 15, 120, async () => {
       const proposals = await SteemService.listProposals({
@@ -81,7 +82,14 @@ export async function GET(request: NextRequest) {
       proposals: result.data.proposals,
       ...(result.degraded && { degraded: true, staleAge: result.staleAge }),
     });
-    response.headers.set('Cache-Control', 'public, s-maxage=15, stale-while-revalidate=120');
+    // When username is present the response includes user-specific upVoted flags,
+    // so use private caching to prevent cross-user CDN poisoning.
+    response.headers.set(
+      'Cache-Control',
+      username
+        ? 'private, max-age=15'
+        : 'public, s-maxage=15, stale-while-revalidate=120'
+    );
     if (result.degraded) response.headers.set('X-Degraded', 'true');
     return response;
   } catch (error) {

--- a/src/app/api/query/vesting-delegations/route.ts
+++ b/src/app/api/query/vesting-delegations/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
 import { withCache } from '@/lib/cache/server-cache';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Missing account parameter' }, { status: 400 });
     }
 
-    const cacheKey = `cache:query:vesting-delegations:${account}`;
+    const cacheKey = hashedCacheKey('cache:query:vesting-delegations', account);
     const result = await withCache(cacheKey, 15, 120, () =>
       SteemService.getVestingDelegations(account)
     );

--- a/src/app/api/query/wallet-estimate-extras/route.ts
+++ b/src/app/api/query/wallet-estimate-extras/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
 import { withCache } from '@/lib/cache/server-cache';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 
 export async function GET(request: NextRequest) {
   try {
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
 
     try {
       const result = await withCache(
-        `cache:query:wallet-estimate-extras:${username}:${includeOpenOrders}`,
+        hashedCacheKey('cache:query:wallet-estimate-extras', username, includeOpenOrders),
         60,
         600,
         () => SteemService.getWalletEstimateExtras(username, { includeOpenOrders })
@@ -45,7 +46,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('wallet-estimate-extras query error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch wallet estimate extras', details: (error as Error).message },
+      { error: 'Failed to fetch wallet estimate extras'},
       { status: 500 }
     );
   }

--- a/src/app/api/query/withdraw-routes/route.ts
+++ b/src/app/api/query/withdraw-routes/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
 import { rateLimit } from '@/lib/middleware';
 import { withCache } from '@/lib/cache/server-cache';
+import { hashedCacheKey } from '@/lib/cache/cache-key';
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
 
     try {
       const result = await withCache(
-        `cache:query:withdraw-routes:${username}`,
+        hashedCacheKey('cache:query:withdraw-routes', username),
         60,
         600,
         () => SteemService.getWithdrawRoutesOutgoing(username)
@@ -43,7 +44,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('withdraw-routes query error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch withdraw routes', details: (error as Error).message },
+      { error: 'Failed to fetch withdraw routes'},
       { status: 500 }
     );
   }

--- a/src/app/api/query/witnesses/route.ts
+++ b/src/app/api/query/witnesses/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     const limitParam = searchParams.get('limit');
     const limit = limitParam ? parseInt(limitParam, 10) : 100;
 
-    if (limit < 1 || limit > 500) {
+    if (!Number.isFinite(limit) || limit < 1 || limit > 500) {
       return NextResponse.json(
         { error: 'Limit must be between 1 and 500' },
         { status: 400 }
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error fetching witnesses:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch witnesses', details: (error as Error).message },
+      { error: 'Failed to fetch witnesses'},
       { status: 500 }
     );
   }

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -180,21 +180,21 @@ export async function trackLogout(username: string): Promise<void> {
  * Track transfer events
  */
 export async function trackTransfer(
-  username: string,
-  amount: string,
-  recipient: string,
+  _username: string,
+  _amount: string,
+  _recipient: string,
   success: boolean,
-  error?: string
+  _error?: string
 ): Promise<void> {
   const eventName = success
     ? 'transfer_success'
     : 'transfer_failure';
 
+  // Do NOT send financial PII (amounts, counterparties) to third-party
+  // analytics. Only track that a transfer was attempted and whether it
+  // succeeded — never the amount or recipient.
   await trackEvent(eventName, {
-    username,
-    amount,
-    recipient,
-    error,
+    success,
   });
 }
 
@@ -202,10 +202,10 @@ export async function trackTransfer(
  * Track power down events
  */
 export async function trackPowerDown(
-  username: string,
-  amount: string,
+  _username: string,
+  _amount: string,
   action: 'initiated' | 'cancelled' | 'success' | 'failure',
-  error?: string
+  _error?: string
 ): Promise<void> {
   const eventMap: Record<string, AnalyticsEvent> = {
     initiated: 'power_down_initiated',
@@ -217,32 +217,27 @@ export async function trackPowerDown(
   const eventName = eventMap[action];
   if (!eventName) return;
 
-  await trackEvent(eventName, {
-    username,
-    amount,
-    error,
-  });
+  await trackEvent(eventName, {});
 }
 
 /**
  * Track delegation events
  */
 export async function trackDelegate(
-  username: string,
-  delegatee: string,
-  amount: string,
+  _username: string,
+  _delegatee: string,
+  _amount: string,
   success: boolean,
-  error?: string
+  _error?: string
 ): Promise<void> {
   const eventName = success
     ? 'delegate_success'
     : 'delegate_failure';
 
   await trackEvent(eventName, {
-    username,
-    delegatee,
-    amount,
-    error,
+    // Omit `amount` and `delegatee` — financial PII must not be sent to
+    // third-party analytics. Only track success/failure.
+    success,
   });
 }
 

--- a/src/lib/cache/cache-key.ts
+++ b/src/lib/cache/cache-key.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'crypto';
+
+/**
+ * Build a collision-resistant Redis cache key from a prefix and user-supplied
+ * components. Each component is SHA-256 hashed (truncated) so that:
+ *   - raw usernames with special chars (`:`, `*`, `\n`) cannot inject into the key,
+ *   - distinct inputs never share a key via prefix collision.
+ *
+ * Use this instead of string-interpolating user input directly into cache keys.
+ */
+export function hashedCacheKey(prefix: string, ...parts: (string | number | boolean)[]): string {
+  const segments = parts.map((p) => {
+    const str = String(p);
+    // Short safe values (numeric/boolean) pass through; strings get hashed.
+    if (/^[a-zA-Z0-9_-]{1,24}$/.test(str)) return str;
+    return createHash('sha256').update(str).digest('hex').slice(0, 16);
+  });
+  return [prefix, ...segments].join(':');
+}

--- a/src/lib/cache/client-cache.ts
+++ b/src/lib/cache/client-cache.ts
@@ -49,7 +49,9 @@ class ClientCache {
 
   invalidate(prefix: string): void {
     for (const key of this.store.keys()) {
-      if (key.includes(prefix)) {
+      // Use startsWith (prefix match), not includes (substring match), so
+      // invalidate('price') does not also evict 'wallet-prices' etc.
+      if (key.startsWith(prefix)) {
         this.store.delete(key);
         this.removeFromOrder(key);
       }

--- a/src/lib/cache/client-fetch.ts
+++ b/src/lib/cache/client-fetch.ts
@@ -51,7 +51,11 @@ export async function cachedFetch<T>(
   const isDegraded = res.headers.get('X-Degraded') === 'true';
   handleCacheInvalidation(res);
   setDegraded(isDegraded);
-  clientCache.set(url, data, opts.staleMs, opts.maxAgeMs);
+  // Only cache successful responses — never cache errors (4xx/5xx) or the user
+  // gets stuck on a stale error page even after the backend recovers.
+  if (res.ok) {
+    clientCache.set(url, data, opts.staleMs, opts.maxAgeMs);
+  }
   return { data, stale: false, degraded: isDegraded || undefined };
 }
 
@@ -62,7 +66,11 @@ function backgroundRefresh(url: string, opts: CachedFetchOptions): void {
       const isDegraded = res.headers.get('X-Degraded') === 'true';
       handleCacheInvalidation(res);
       setDegraded(isDegraded);
-      clientCache.set(url, data, opts.staleMs, opts.maxAgeMs);
+      // Only refresh-cache on success — a transient error must not replace
+      // good cached data with an error body.
+      if (res.ok) {
+        clientCache.set(url, data, opts.staleMs, opts.maxAgeMs);
+      }
     })
     .catch(() => {});
 }

--- a/src/lib/wallet/change-password.ts
+++ b/src/lib/wallet/change-password.ts
@@ -8,7 +8,13 @@ const AUTHORITY_ROLES: Exclude<PasswordAuthRole, 'memo'>[] = ['owner', 'active',
 
 /** Generate a random master password prefixed with P (legacy wallet-legacy parity). */
 export function generateNewMasterPassword(): string {
-  const entropy = `${Date.now()}-${Math.random()}-${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : ''}`;
+  // Use cryptographically strong entropy only — fail-closed if crypto is
+  // unavailable (do NOT fall back to Math.random, which is predictable).
+  const c = typeof globalThis !== 'undefined' && (globalThis as { crypto?: Crypto }).crypto;
+  if (!c || typeof c.randomUUID !== 'function') {
+    throw new Error('secure entropy source unavailable');
+  }
+  const entropy = `${Date.now()}-${c.randomUUID()}`;
   return `P${steem.auth.getPrivateKey(entropy)}`;
 }
 

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -125,59 +125,52 @@ describe('typed wrappers route to the correct event + payload', () => {
       name: 'trackTransfer success',
       call: () => trackTransfer('alice', '1.000 STEEM', 'bob', true),
       event: 'transfer_success',
-      properties: { username: 'alice', amount: '1.000 STEEM', recipient: 'bob' },
+      // PII (username, amount, recipient) is scrubbed — only success is tracked.
+      properties: { success: true },
     },
     {
       name: 'trackTransfer failure',
       call: () => trackTransfer('alice', '1.000 STEEM', 'bob', false, 'Insufficient'),
       event: 'transfer_failure',
-      properties: {
-        username: 'alice',
-        amount: '1.000 STEEM',
-        recipient: 'bob',
-        error: 'Insufficient',
-      },
+      properties: { success: false },
     },
     {
       name: 'trackPowerDown initiated',
       call: () => trackPowerDown('alice', '1.000000 VESTS', 'initiated'),
       event: 'power_down_initiated',
-      properties: { username: 'alice', amount: '1.000000 VESTS' },
+      // PII (username, amount) is scrubbed.
+      properties: {},
     },
     {
       name: 'trackPowerDown cancelled',
       call: () => trackPowerDown('alice', '0.000000 VESTS', 'cancelled'),
       event: 'power_down_cancelled',
-      properties: { username: 'alice', amount: '0.000000 VESTS' },
+      properties: {},
     },
     {
       name: 'trackPowerDown success',
       call: () => trackPowerDown('alice', '1.000000 VESTS', 'success'),
       event: 'power_down_success',
-      properties: { username: 'alice', amount: '1.000000 VESTS' },
+      properties: {},
     },
     {
       name: 'trackPowerDown failure',
       call: () => trackPowerDown('alice', '1.000000 VESTS', 'failure', 'Invalid vests'),
       event: 'power_down_failure',
-      properties: { username: 'alice', amount: '1.000000 VESTS', error: 'Invalid vests' },
+      properties: {},
     },
     {
       name: 'trackDelegate success',
       call: () => trackDelegate('alice', 'bob', '1.000000 VESTS', true),
       event: 'delegate_success',
-      properties: { username: 'alice', delegatee: 'bob', amount: '1.000000 VESTS' },
+      // PII (username, delegatee, amount) is scrubbed — only success is tracked.
+      properties: { success: true },
     },
     {
       name: 'trackDelegate failure',
       call: () => trackDelegate('alice', 'bob', '1.000000 VESTS', false, 'Insufficient'),
       event: 'delegate_failure',
-      properties: {
-        username: 'alice',
-        delegatee: 'bob',
-        amount: '1.000000 VESTS',
-        error: 'Insufficient',
-      },
+      properties: { success: false },
     },
     {
       name: 'trackWitnessVote vote',

--- a/tests/unit/client-cache.test.ts
+++ b/tests/unit/client-cache.test.ts
@@ -65,16 +65,28 @@ describe('ClientCache', () => {
     expect(clientCache.get('key-1')).not.toBeNull();
   });
 
-  it('invalidates entries by prefix substring match', () => {
+  it('invalidates entries by prefix match (not substring)', () => {
     clientCache.set('user:alice:balance', 100, 60_000, 120_000);
     clientCache.set('user:alice:history', [], 60_000, 120_000);
     clientCache.set('user:bob:balance', 200, 60_000, 120_000);
 
-    clientCache.invalidate('alice');
+    // Prefix match: 'user:alice:' evicts alice's entries but not bob's.
+    clientCache.invalidate('user:alice:');
 
     expect(clientCache.get('user:alice:balance')).toBeNull();
     expect(clientCache.get('user:alice:history')).toBeNull();
     expect(clientCache.get('user:bob:balance')).not.toBeNull();
+  });
+
+  it('does NOT invalidate by substring (e.g. invalidate(price) should not evict wallet-prices)', () => {
+    clientCache.set('/api/price', 1, 60_000, 120_000);
+    clientCache.set('/api/wallet-prices', 2, 60_000, 120_000);
+
+    clientCache.invalidate('/api/price');
+
+    expect(clientCache.get('/api/price')).toBeNull();
+    // wallet-prices does not START with /api/price → must survive.
+    expect(clientCache.get('/api/wallet-prices')).not.toBeNull();
   });
 
   it('clear() removes all entries', () => {

--- a/tests/unit/client-fetch.test.ts
+++ b/tests/unit/client-fetch.test.ts
@@ -7,8 +7,9 @@ import { cachedFetch } from '@/lib/cache/client-fetch';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-function jsonResponse(data: unknown, headers: Record<string, string> = {}): Response {
+function jsonResponse(data: unknown, headers: Record<string, string> = {}, ok = true): Response {
   return {
+    ok,
     json: () => Promise.resolve(data),
     headers: new Headers(headers),
   } as unknown as Response;
@@ -125,7 +126,7 @@ describe('cachedFetch', () => {
 
   it('invalidates cache on X-Cache-Invalidate header', async () => {
     mockFetch.mockResolvedValueOnce(
-      jsonResponse({ value: 1 }, { 'X-Cache-Invalidate': 'alice' })
+      jsonResponse({ value: 1 }, { 'X-Cache-Invalidate': 'user:alice:' })
     );
 
     clientCache.set('user:alice:balance', 100, 60_000, 120_000);
@@ -133,7 +134,7 @@ describe('cachedFetch', () => {
 
     await cachedFetch('/api/test', { staleMs: 10_000, maxAgeMs: 30_000 });
 
-    // alice entries should be invalidated
+    // alice entries should be invalidated (prefix match)
     expect(clientCache.get('user:alice:balance')).toBeNull();
     expect(clientCache.get('user:bob:balance')).not.toBeNull();
   });


### PR DESCRIPTION
## Summary

Batch-fixes 9 audit V2 findings (7 medium, 2 low) across query routes, caching, analytics, and client-side code.

## Changes by finding

| Finding | Severity | Fix |
|---------|----------|-----|
| V2-5 | Medium | `history`/`witnesses` `limit` validation now uses `Number.isFinite` — `parseInt('abc')`→`NaN` bypassed the `<` / `>` range check. |
| V2-6 | Medium | Strip `details: error.message` from 6 query-route 500 responses (`history`, `market`, `witnesses`, `withdraw-routes`, `wallet-estimate-extras`, `median-history-price`). |
| V2-7 | Medium | New `hashedCacheKey()` helper SHA-256-hashes user-supplied components into Redis cache keys (7 routes). Prevents key collision / cross-user cache poisoning via special chars in usernames. |
| V2-8 | Medium | `proposals` route sets `Cache-Control: private` when `username` is present (response contains user-specific `upVoted` flags). |
| V2-9 | Medium | `client-fetch.ts` only caches 2xx responses — 4xx/5xx error bodies no longer cached for full `maxAgeMs`. |
| V2-10 | Medium | `market` route now uses `withCache` (5s/30s) instead of fanning out 4 parallel RPCs per uncached request. |
| V2-11 | Medium | Analytics `trackTransfer`/`trackPowerDown`/`trackDelegate` scrub financial PII (amounts, recipients, counterparties) — only success/failure tracked. |
| V2-12 | Low | `change-password.ts` master-password generator uses `crypto.randomUUID` only (fail-closed), no longer mixes `Math.random`. |
| V2-16 | Low | `client-cache.invalidate()` uses `startsWith` (prefix) not `includes` (substring) — `invalidate('/api/price')` no longer evicts `/api/wallet-prices`. |

## New files

- `src/lib/cache/cache-key.ts` — `hashedCacheKey()` helper for collision-resistant cache keys.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 477 passed (analytics, client-cache, client-fetch tests updated for new behavior)