### PR TITLE
fix(security): V2-13/15/17 — normalize-before-verify, dead code, console gating

### DIFF
--- a/src/app/api/broadcast/recover-account/route.ts
+++ b/src/app/api/broadcast/recover-account/route.ts
@@ -120,9 +120,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Verify the transaction signature against the claimed (now validated) key.
+    // Normalize the transaction for broadcast BEFORE verifying the signature,
+    // so the verified digest is exactly what gets broadcast. This makes the
+    // verify→broadcast digest consistency explicit rather than relying on
+    // verifyTransaction's internal normalization (an undocumented library
+    // behavior that could change in a future release).
+    const txForBroadcast = steem.auth.normalizeTransactionForBroadcast(
+      signedTx as unknown as Record<string, unknown>
+    ) as unknown as SignedTransaction;
+
+    // Verify the transaction signature against the claimed (now validated) key,
+    // on the normalized transaction (same digest that will be broadcast).
     if (!steem.auth.verifyTransaction(
-      signedTx as unknown as Record<string, unknown>,
+      txForBroadcast as unknown as Record<string, unknown>,
       claimedRecentKey
     )) {
       return NextResponse.json(
@@ -172,10 +182,6 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-
-    const txForBroadcast = steem.auth.normalizeTransactionForBroadcast(
-      signedTx as unknown as Record<string, unknown>
-    ) as unknown as SignedTransaction;
 
     const result = await SteemService.broadcastTransaction(txForBroadcast);
 

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -289,7 +289,7 @@ export function LoginForm(props: LoginFormProps = {}) {
         });
       }
     } catch (err) {
-      console.error('Login error:', err);
+      if (process.env.NODE_ENV !== 'production') console.error('Login error:', err);
       setError(tCommon('error'));
       setIsLoading(false);
     }

--- a/src/components/wallet/recover-account-confirmation-page.tsx
+++ b/src/components/wallet/recover-account-confirmation-page.tsx
@@ -119,12 +119,12 @@ export function RecoverAccountConfirmationPage({ code }: { code: string }) {
         const { signedTx } = await SteemSigner.signRecoverAccount(name, oldPwd, newPwd);
         const broadcastRes = await apiClient.broadcastRecoverAccountTx(signedTx);
         if (!broadcastRes.success) {
-          console.warn('recover_account broadcast returned error:', broadcastRes.error);
+          if (process.env.NODE_ENV !== 'production') console.warn('recover_account broadcast returned error:', broadcastRes.error);
         }
       } catch (broadcastErr) {
         // Server already recorded the recovery, but broadcast failed.
         // The user can retry broadcast later. Don't block the success UI.
-        console.warn('Client-side recover_account broadcast failed:', broadcastErr);
+        if (process.env.NODE_ENV !== 'production') console.warn('Client-side recover_account broadcast failed:', broadcastErr);
       }
 
       setSuccess(true);

--- a/src/components/wallet/transfer-form.tsx
+++ b/src/components/wallet/transfer-form.tsx
@@ -151,7 +151,7 @@ export function TransferForm({
         }
       });
     } catch (err) {
-      console.error('Transfer error:', err);
+      if (process.env.NODE_ENV !== 'production') console.error('Transfer error:', err);
       setError('Failed to process transfer');
       setIsLoading(false);
     }

--- a/src/lib/middleware/rate-limit.ts
+++ b/src/lib/middleware/rate-limit.ts
@@ -235,30 +235,3 @@ export async function rateLimitByUser(
 
   return memoryRateLimit(key, config);
 }
-
-export function getRateLimitInfo(
-  request: NextRequest,
-  action: string,
-  config: RateLimitConfig
-): { limit: number; remaining: number; resetAt: Date } | null {
-  const ip = getClientIP(request);
-  const routeScope =
-    request.nextUrl?.pathname?.replace(/^\/api\/broadcast\//, 'broadcast:') ?? '';
-  const key = `${ip}:${action}${routeScope ? `:${routeScope}` : ''}`;
-  const entry = memoryStore.get(key);
-  if (!entry) return null;
-
-  return {
-    limit: config.maxRequests,
-    remaining: Math.max(0, config.maxRequests - entry.count),
-    resetAt: new Date(entry.resetAt),
-  };
-}
-
-export function resetRateLimit(request: NextRequest, action: string): void {
-  const ip = getClientIP(request);
-  const routeScope =
-    request.nextUrl?.pathname?.replace(/^\/api\/broadcast\//, 'broadcast:') ?? '';
-  const key = `${ip}:${action}${routeScope ? `:${routeScope}` : ''}`;
-  memoryStore.delete(key);
-}

--- a/tests/unit/rate-limit-proxy.test.ts
+++ b/tests/unit/rate-limit-proxy.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/lib/cache/redis', () => ({
   cacheDeleteByPrefix: vi.fn(),
 }));
 
-import { rateLimit, rateLimitByUser, getRateLimitInfo } from '@/lib/middleware/rate-limit';
+import { rateLimit, rateLimitByUser } from '@/lib/middleware/rate-limit';
 
 function makeReq(headers: Record<string, string> = {}, path = '/api/broadcast/transfer'): NextRequest {
   const url = new URL(`http://localhost${path}`);
@@ -132,27 +132,5 @@ describe('rateLimitByUser', () => {
     expect(res).not.toBeNull();
     expect(res!.status).toBe(503);
     delete process.env.RATE_LIMIT_ALLOW_MEMORY_FALLBACK;
-  });
-});
-
-describe('getRateLimitInfo', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetRedis.mockReturnValue(null);
-  });
-
-  it('returns null when no entry exists', () => {
-    // Use a unique action so no prior test pollutes the memory bucket.
-    const info = getRateLimitInfo(makeReq(), 'never-used-action', { maxRequests: 10, windowSeconds: 60 });
-    expect(info).toBeNull();
-  });
-
-  it('returns limit/remaining after a request', async () => {
-    const req = makeReq({}, '/api/broadcast/vote');
-    await rateLimit(req, 'broadcast', { maxRequests: 5, windowSeconds: 60 });
-    const info = getRateLimitInfo(req, 'broadcast', { maxRequests: 5, windowSeconds: 60 });
-    expect(info).not.toBeNull();
-    expect(info!.limit).toBe(5);
-    expect(info!.remaining).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary

Closes the last 3 low-severity findings from audit V2.

## Changes

**V2-13 (low) — `src/app/api/broadcast/recover-account/route.ts`**
Move `normalizeTransactionForBroadcast` BEFORE signature verification, so the verified digest is exactly what gets broadcast. Previously the signature was verified on the raw `signedTx` while broadcast used the normalized form — safe today only because `verifyTransaction` internally normalizes too (an undocumented library behavior). Now the consistency is explicit.

**V2-15 (low) — `src/lib/middleware/rate-limit.ts`**
Remove dead code: `getRateLimitInfo()` and `resetRateLimit()` had zero callers anywhere in the codebase. Remove the corresponding test block + import from `rate-limit-proxy.test.ts`.

**V2-17 (low) — `login-form.tsx`, `transfer-form.tsx`, `recover-account-confirmation-page.tsx`**
Gate 4 `console.error`/`console.warn` calls behind `process.env.NODE_ENV !== 'production'`, matching the existing pattern in `analytics/index.ts`. Prevents error objects (which may embed user input) from appearing in the production browser console.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 475 passed (2 removed: deleted getRateLimitInfo tests)