### PR TITLE
fix(security): rate-limit the auth challenge endpoint (F6/S2)

### DIFF
--- a/src/app/api/auth/challenge/route.ts
+++ b/src/app/api/auth/challenge/route.ts
@@ -2,7 +2,7 @@
 // Generate a login challenge for the user
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
-import { setCSRFToken } from '@/lib/middleware';
+import { setCSRFToken, rateLimit, rateLimitByUser } from '@/lib/middleware';
 import { getRedis, redisKey } from '@/lib/cache/redis';
 
 const CHALLENGE_TTL = 300; // 5 minutes
@@ -26,6 +26,24 @@ export async function GET(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // Rate limit BEFORE any Redis write. Two dimensions:
+    //  - per-IP: bounds the write-amplification surface (this endpoint is
+    //    unauthenticated; without a limit it can drive unbounded Redis writes).
+    //  - per-username: an attacker hammering challenges for one victim
+    //    otherwise overwrites the victim's challenge on every attempt,
+    //    locking them out of login (targeted auth DoS).
+    const ipLimit = await rateLimit(request, 'auth_challenge', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+    if (ipLimit) return ipLimit;
+
+    const userLimit = await rateLimitByUser(username, 'auth_challenge', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+    if (userLimit) return userLimit;
 
     // Generate challenge
     const challenge = SteemService.generateChallenge(username);

--- a/tests/unit/auth-challenge-route.test.ts
+++ b/tests/unit/auth-challenge-route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock middleware — rate limiting is the security behavior under test
+const mockRateLimit = vi.fn();
+const mockRateLimitByUser = vi.fn();
+vi.mock('@/lib/middleware', () => ({
+  setCSRFToken: vi.fn(),
+  rateLimit: (...args: unknown[]) => mockRateLimit(...args),
+  rateLimitByUser: (...args: unknown[]) => mockRateLimitByUser(...args),
+  verifyCSRF: vi.fn(),
+}));
+
+// Mock SteemService
+const mockGenerateChallenge = vi.fn();
+vi.mock('@/lib/steem/server', () => ({
+  SteemService: {
+    generateChallenge: (...args: unknown[]) => mockGenerateChallenge(...args),
+  },
+}));
+
+// Mock Redis
+const mockRedisSet = vi.fn();
+const mockGetRedis = vi.fn();
+vi.mock('@/lib/cache/redis', () => ({
+  getRedis: () => mockGetRedis(),
+  redisKey: (k: string) => `wallet:${k}`,
+}));
+
+import { GET } from '@/app/api/auth/challenge/route';
+
+function makeRequest(username?: string): NextRequest {
+  const qs = username ? `?username=${encodeURIComponent(username)}` : '';
+  return new NextRequest(`http://localhost/api/auth/challenge${qs}`);
+}
+
+describe('GET /api/auth/challenge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRateLimit.mockResolvedValue(null);
+    mockRateLimitByUser.mockResolvedValue(null);
+    mockGenerateChallenge.mockReturnValue('login-alice-123-abc');
+    mockGetRedis.mockReturnValue({ set: mockRedisSet });
+  });
+
+  it('generates and stores a challenge for a valid username', async () => {
+    const res = await GET(makeRequest('alice'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.challenge).toBe('login-alice-123-abc');
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      'wallet:auth:challenge:alice',
+      expect.stringContaining('login-alice-123-abc'),
+      'EX',
+      300
+    );
+  });
+
+  it('returns 400 when username is missing', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(400);
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid username format (before any Redis write)', async () => {
+    const res = await GET(makeRequest('Bad Name!'));
+    expect(res.status).toBe(400);
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when the per-IP rate limit trips', async () => {
+    mockRateLimit.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Too many requests' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const res = await GET(makeRequest('alice'));
+    expect(res.status).toBe(429);
+    // Per-username limiter must not run once IP limit already blocked.
+    expect(mockRateLimitByUser).not.toHaveBeenCalled();
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when the per-username rate limit trips (targeted auth-DoS guard)', async () => {
+    mockRateLimitByUser.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Too many requests' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const res = await GET(makeRequest('alice'));
+    expect(res.status).toBe(429);
+    // The overwrite attack vector: challenge must NOT be written when limited.
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it('rate limits with the auth_challenge action at 10/min', async () => {
+    await GET(makeRequest('alice'));
+    expect(mockRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'auth_challenge',
+      { maxRequests: 10, windowSeconds: 60 }
+    );
+    expect(mockRateLimitByUser).toHaveBeenCalledWith('alice', 'auth_challenge', {
+      maxRequests: 10,
+      windowSeconds: 60,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes audit findings **F6** (Claude Security) and **S2** (security team) — the same issue found independently by both audits: `/api/auth/challenge` was the **only writing endpoint with no rate limit** across all 43 HTTP entries.

## The vulnerability

The endpoint is unauthenticated; `username` is format-checked but not existence-checked, and every request unconditionally `SET`s (overwrites) a 300s-TTL Redis key. Two attack vectors:

1. **Targeted auth DoS** — an attacker hammering challenges for one victim overwrites the victim's challenge on every attempt, so the victim's signed challenge never matches at login (`401 Invalid signature`). Permanent lockout. The security team's vitest PoC: 500 requests, all 200, zero 429s.
2. **Unbounded Redis write amplification** — challenge storage, rate limiting, and query caching share one Redis instance. Flooding challenge keys (for the entire username space, including non-existent accounts) exhausts it and cascades: login goes fail-closed (503), the rate limiter degrades to per-process memory, and query-cache misses hit the Steem RPC directly.

## Fix

Two-dimensional rate limiting, applied **before any Redis write**:

```
per-IP:        rateLimit(request, 'auth_challenge', 10/min)
per-username:  rateLimitByUser(username, 'auth_challenge', 10/min)
```

- Per-IP bounds the write-amplification surface.
- Per-username bounds the overwrite vector (the targeted-DoS primitive).

## Scope note

Login is a **stateful server-side flow** (the challenge store is server state), so this fix is outside the pure-relay rollback (#314) — that covered broadcast routes only. The relay philosophy does not apply here.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 460 passed (6 new: generation/persistence, validation order before limit/write, both 429 paths, exact limit parameters)