### PR TITLE
fix(security): recovery lookup filters by closed status, newest first, and consumes on success (F15)

### DIFF
--- a/docs/ACCOUNT_RECOVERY.md
+++ b/docs/ACCOUNT_RECOVERY.md
@@ -73,6 +73,8 @@ User Browser          Wallet (Next.js)         turtle            kingdom
     │                      │  condenser_api      │                  │
     │                      │  .broadcast_        │                  │
     │                      │  transaction        │                  │
+    │                      │  Update arecs       │                  │
+    │                      │  status=consumed    │                  │
     │<─────success─────────│                     │                  │
 ```
 
@@ -134,6 +136,9 @@ a link like `https://steemitwallet.com/account_recovery_confirmation/{code}`.
 2. The signed transaction is sent to the server relay endpoint.
 3. Server validates the transaction format (op must be `recover_account`) and
    broadcasts via `condenser_api.broadcast_transaction`.
+4. On broadcast success the server consumes the row (`status='consumed'`).
+   Consume is best-effort: a DB error after a successful relay still returns
+   200, because the on-chain `recover_account` already took effect.
 
 ---
 
@@ -152,7 +157,7 @@ a link like `https://steemitwallet.com/account_recovery_confirmation/{code}`.
 | `memo_key` | TEXT NULL | Memo key |
 | `provider` | VARCHAR(32) | Auth provider (e.g. `email`) |
 | `remote_ip` | VARCHAR(64) | Client IP |
-| `status` | ENUM(open, confirmed, expired, closed) | Request lifecycle |
+| `status` | varchar(32): open, confirmed, processing, expired, closed, consumed | Request lifecycle |
 | `email_confirmation_code` | VARCHAR(255) NULL | Email verification code |
 | `validation_code` | VARCHAR(255) NULL | 20-hex-char code in the recovery email link |
 | `request_submitted_at` | DATETIME NULL | When step 2 was completed |
@@ -162,16 +167,20 @@ a link like `https://steemitwallet.com/account_recovery_confirmation/{code}`.
 ### Status lifecycle
 
 ```
-open → confirmed → processing → closed
+open → confirmed → processing → closed → consumed
               ↘ expired
 ```
 
 - `open`: User submitted step 1, awaiting admin review.
 - `confirmed`: Admin approved, `validation_code` generated, email sent.
-- `processing`: User submitted step 2 confirm; server has claimed the record atomically (CAS). If `kingdom.recovery_account` fails, the record stays in `processing`. **Records stuck in `processing` for >1 hour should be manually reset to `confirmed` by ops** to allow retry.
+- `processing`: Confirm CAS claim. On kingdom/RPC failure the record is rolled
+  back to `confirmed` so the user can retry.
 - `expired`: Code expired (timeout, not currently enforced automatically).
-- `closed`: User completed step 2, recovery done. The `validation_code` is now
-  single-use (cannot be used again).
+- `closed`: Confirm succeeded (`request_account_recovery` is on-chain). The
+  `validation_code` is now single-use. This row authorizes one
+  `recover_account` broadcast via `/api/broadcast/recover-account`.
+- `consumed`: `recover_account` broadcast succeeded. The row can no longer
+  authorize another relay. Terminal state.
 
 ---
 
@@ -226,7 +235,8 @@ open → confirmed → processing → closed
 3. **Rate limiting** on all recovery endpoints to prevent abuse.
 4. **Code validation** — 20-hex-char format enforced server-side.
 5. **Owner key format validation** — strict base58 regex `^STM[1-9A-HJ-NP-Za-km-z]{50}$` (excludes 0/O/I/l).
-6. **Single-use codes** — `status` changes to `closed` after successful step 2,
-   preventing replay.
+6. **Single-use codes** — `status` changes to `closed` after successful confirm
+   (step 2b), then to `consumed` after a successful `recover_account` broadcast
+   (step 2c), preventing replay.
 7. **Account name verification** — Server checks that the account name from the
    arecs record matches the submitted one.

--- a/src/app/api/broadcast/recover-account/route.ts
+++ b/src/app/api/broadcast/recover-account/route.ts
@@ -2,7 +2,7 @@
 // Broadcast a signed recover_account transaction (step 2 of account recovery)
 import { NextRequest, NextResponse } from 'next/server';
 import { steem } from '@steemit/steem-js';
-import { eq } from 'drizzle-orm';
+import { eq, and, desc } from 'drizzle-orm';
 import { SteemService } from '@/lib/steem/server';
 import { verifyCSRF, rateLimit } from '@/lib/middleware';
 import { getDb } from '@/lib/db';
@@ -164,9 +164,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Look up the LATEST closed recovery record for this account.
+    // The arecs table has only a non-unique index on account_name and
+    // /api/recovery/request lets ANYONE insert rows for ANY account name —
+    // so an attacker can pre-insert a stale 'open' row. Without the status
+    // predicate + newest-first ordering, findFirst could return the
+    // attacker's row and permanently reject the victim's recovery
+    // (recovery denial, not takeover).
     const record = await db.query.arecs.findFirst({
-      where: eq(arecs.accountName, opBody.account_to_recover),
+      where: and(
+        eq(arecs.accountName, opBody.account_to_recover),
+        eq(arecs.status, 'closed')
+      ),
       columns: { id: true, status: true, newOwnerKey: true },
+      orderBy: [desc(arecs.id)],
     });
 
     if (!record || record.status !== 'closed') {
@@ -184,6 +195,16 @@ export async function POST(request: NextRequest) {
     }
 
     const result = await SteemService.broadcastTransaction(txForBroadcast);
+
+    // Consume the record on success: the on-chain recover_account can only
+    // be used once per request_account_recovery, so a closed record must
+    // not authorize a second broadcast (replay hardening). A CAS on
+    // status='closed' keeps a concurrent request from consuming a record
+    // that already flipped.
+    await db
+      .update(arecs)
+      .set({ status: 'consumed' })
+      .where(and(eq(arecs.id, record.id), eq(arecs.status, 'closed')));
 
     return NextResponse.json({ success: true, result });
   } catch (error) {

--- a/src/app/api/broadcast/recover-account/route.ts
+++ b/src/app/api/broadcast/recover-account/route.ts
@@ -196,15 +196,31 @@ export async function POST(request: NextRequest) {
 
     const result = await SteemService.broadcastTransaction(txForBroadcast);
 
-    // Consume the record on success: the on-chain recover_account can only
-    // be used once per request_account_recovery, so a closed record must
-    // not authorize a second broadcast (replay hardening). A CAS on
-    // status='closed' keeps a concurrent request from consuming a record
-    // that already flipped.
-    await db
-      .update(arecs)
-      .set({ status: 'consumed' })
-      .where(and(eq(arecs.id, record.id), eq(arecs.status, 'closed')));
+    // Consume is best-effort replay hardening. The on-chain recover_account
+    // is already single-use per request_account_recovery; a DB error here
+    // must not turn a successful recovery into HTTP 500 ("Failed to
+    // broadcast"). CAS on id + status='closed' so a concurrent request
+    // cannot consume a row that already flipped — 0 affectedRows is logged,
+    // not treated as failure, because the broadcast already succeeded.
+    try {
+      const consumeResult = await db
+        .update(arecs)
+        .set({ status: 'consumed' })
+        .where(and(eq(arecs.id, record.id), eq(arecs.status, 'closed')));
+      const affected = (consumeResult as unknown as { affectedRows?: number })
+        .affectedRows;
+      if (!affected || affected === 0) {
+        console.warn(
+          'recover-account consume CAS updated 0 rows (already consumed?)',
+          { id: record.id }
+        );
+      }
+    } catch (consumeError) {
+      console.error(
+        'recover-account consume failed after successful broadcast:',
+        consumeError
+      );
+    }
 
     return NextResponse.json({ success: true, result });
   } catch (error) {

--- a/tests/unit/broadcast-recover-account-route.test.ts
+++ b/tests/unit/broadcast-recover-account-route.test.ts
@@ -39,6 +39,7 @@ const VALID_KEY_B = 'STM' + B58.slice(1, 51);
 
 const mockFindFirst = vi.fn();
 let mockUpdateFn: ReturnType<typeof vi.fn>;
+let mockUpdateWhere: ReturnType<typeof vi.fn>;
 const mockDb = {
   query: {
     arecs: {
@@ -103,11 +104,11 @@ describe('POST /api/broadcast/recover-account', () => {
       status: 'closed',
       newOwnerKey: VALID_KEY_B,
     });
-    // Default update chain: .set().where() resolves
-    const chain = {
-      where: vi.fn().mockResolvedValue(undefined),
-    };
-    mockUpdateFn = vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue(chain) });
+    // Default update chain: .set().where() resolves with a winning CAS
+    mockUpdateWhere = vi.fn().mockResolvedValue({ affectedRows: 1 });
+    mockUpdateFn = vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: mockUpdateWhere }),
+    });
     // Default: owner history contains VALID_KEY_A (the recentKey in makeSignedTx)
     mockGetOwnerHistory.mockResolvedValue([
       { previous_owner_authority: { key_auths: [[VALID_KEY_A, 1]] } },
@@ -328,9 +329,11 @@ describe('POST /api/broadcast/recover-account', () => {
       where: SQL;
       orderBy: SQL[];
     };
-    const whereSql = dialect.sqlToQuery(arg.where).sql;
-    expect(whereSql).toContain('account_name');
-    expect(whereSql).toContain('status');
+    const whereQuery = dialect.sqlToQuery(arg.where);
+    expect(whereQuery.sql).toContain('account_name');
+    expect(whereQuery.sql).toContain('status');
+    expect(whereQuery.params).toContain('alice');
+    expect(whereQuery.params).toContain('closed');
     expect(dialect.sqlToQuery(arg.orderBy[0]!).sql).toContain('`id` desc');
   });
 
@@ -339,10 +342,18 @@ describe('POST /api/broadcast/recover-account', () => {
     const res = await POST(req);
     expect(res.status).toBe(200);
 
-    // The record must be flipped to 'consumed' after broadcast success.
+    // The record must be flipped to 'consumed' after broadcast success,
+    // CAS-guarded on id + status='closed'.
     expect(mockUpdateFn).toHaveBeenCalledTimes(1);
     const setFn = (mockUpdateFn.mock.results[0]?.value as { set?: unknown }).set;
     expect(setFn).toHaveBeenCalledWith({ status: 'consumed' });
+
+    const dialect = new MySqlDialect();
+    const whereQuery = dialect.sqlToQuery(mockUpdateWhere.mock.calls[0]![0] as SQL);
+    expect(whereQuery.sql).toContain('id');
+    expect(whereQuery.sql).toContain('status');
+    expect(whereQuery.params).toContain(1);
+    expect(whereQuery.params).toContain('closed');
   });
 
   it('F15: broadcast failure leaves the record closed (retryable)', async () => {
@@ -355,5 +366,27 @@ describe('POST /api/broadcast/recover-account', () => {
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(mockUpdateFn).not.toHaveBeenCalled();
+  });
+
+  it('F15: consume failure after a successful broadcast still returns 200', async () => {
+    mockUpdateWhere.mockRejectedValueOnce(new Error('DB error'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = makeRequest({ signedTx: makeSignedTx() });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('F15: consume CAS with 0 affectedRows still returns 200 (already consumed)', async () => {
+    mockUpdateWhere.mockResolvedValueOnce({ affectedRows: 0 });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const req = makeRequest({ signedTx: makeSignedTx() });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/tests/unit/broadcast-recover-account-route.test.ts
+++ b/tests/unit/broadcast-recover-account-route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POST } from '@/app/api/broadcast/recover-account/route';
 import { NextRequest } from 'next/server';
+import { MySqlDialect } from 'drizzle-orm/mysql-core';
+import type { SQL } from 'drizzle-orm';
 
 // Mock middleware
 vi.mock('@/lib/middleware', () => ({
@@ -36,11 +38,15 @@ const VALID_KEY_A = 'STM' + B58.slice(0, 50);
 const VALID_KEY_B = 'STM' + B58.slice(1, 51);
 
 const mockFindFirst = vi.fn();
+let mockUpdateFn: ReturnType<typeof vi.fn>;
 const mockDb = {
   query: {
     arecs: {
       findFirst: mockFindFirst,
     },
+  },
+  get update() {
+    return mockUpdateFn;
   },
 };
 const mockGetDb = vi.fn().mockReturnValue(mockDb);
@@ -97,6 +103,11 @@ describe('POST /api/broadcast/recover-account', () => {
       status: 'closed',
       newOwnerKey: VALID_KEY_B,
     });
+    // Default update chain: .set().where() resolves
+    const chain = {
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    mockUpdateFn = vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue(chain) });
     // Default: owner history contains VALID_KEY_A (the recentKey in makeSignedTx)
     mockGetOwnerHistory.mockResolvedValue([
       { previous_owner_authority: { key_auths: [[VALID_KEY_A, 1]] } },
@@ -302,5 +313,47 @@ describe('POST /api/broadcast/recover-account', () => {
     expect(res.status).toBe(500);
     const data = await res.json();
     expect(data.error).toBe('Failed to broadcast transaction');
+  });
+
+  it('F15: queries ONLY closed records, newest first (attacker pre-inserted rows cannot block recovery)', async () => {
+    const req = makeRequest({ signedTx: makeSignedTx() });
+    await POST(req);
+
+    // Render the actual drizzle where/orderBy to SQL and assert the
+    // semantics: status='closed' filter + newest-first ordering, so an
+    // attacker's stale 'open' row for the same account can never be
+    // selected and deny the victim's recovery.
+    const dialect = new MySqlDialect();
+    const arg = mockFindFirst.mock.calls[0]![0] as {
+      where: SQL;
+      orderBy: SQL[];
+    };
+    const whereSql = dialect.sqlToQuery(arg.where).sql;
+    expect(whereSql).toContain('account_name');
+    expect(whereSql).toContain('status');
+    expect(dialect.sqlToQuery(arg.orderBy[0]!).sql).toContain('`id` desc');
+  });
+
+  it('F15: consumes the record after a successful broadcast (replay hardening)', async () => {
+    const req = makeRequest({ signedTx: makeSignedTx() });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // The record must be flipped to 'consumed' after broadcast success.
+    expect(mockUpdateFn).toHaveBeenCalledTimes(1);
+    const setFn = (mockUpdateFn.mock.results[0]?.value as { set?: unknown }).set;
+    expect(setFn).toHaveBeenCalledWith({ status: 'consumed' });
+  });
+
+  it('F15: broadcast failure leaves the record closed (retryable)', async () => {
+    const { SteemService } = await import('@/lib/steem/server');
+    vi.mocked(SteemService.broadcastTransaction).mockRejectedValueOnce(
+      new Error('Network error')
+    );
+
+    const req = makeRequest({ signedTx: makeSignedTx() });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(mockUpdateFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes audit finding **F15** (MEDIUM): recovery **denial** via pre-inserted `arecs` rows.

## The vulnerability

The `recover-account` DB lookup queried `arecs` by `account_name` with **no status predicate and no ordering**. `account_name` has only a **non-unique index**, and `/api/recovery/request` lets anyone insert rows for **any** account name. So an attacker could pre-insert a stale `open` row for the victim; `findFirst` returns the lowest-id row (the attacker's), the route sees `status !== 'closed'`, and the victim's `recover_account` is **permanently rejected** — blocking the recovery of a compromised account (denial, not takeover; 3/3 verifiers confirmed).

## Fix (all three audit recommendations)

1. **`eq(status, 'closed')`** in the query — only completed recovery records can match.
2. **`orderBy desc(id)`** — when multiple closed rows exist, the latest wins.
3. **Consume on success** — after a successful broadcast the record flips to `'consumed'` (CAS on `id` + `'closed'`). On-chain `recover_account` is single-use per `request_account_recovery`, so a closed record must not authorize a second broadcast (replay hardening). Broadcast failure leaves it `closed` for retry.

## Tests

- **SQL-level assertions** via `MySqlDialect` rendering (robust against drizzle internals): where contains `account_name` + `status`; orderBy renders `` `id` desc ``
- Consumption: `set({ status: 'consumed' })` called exactly once on success
- Failure path: record untouched (retryable)

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 475 passed (+3)