### PR TITLE
fix(security): strict whitelist for new_owner_authority in recovery confirm (S3)

### DIFF
--- a/src/app/api/recovery/confirm/route.ts
+++ b/src/app/api/recovery/confirm/route.ts
@@ -65,21 +65,38 @@ export async function POST(request: NextRequest) {
   // This also closes the DB/chain divergence: the key stored in arecs
   // (new_owner_key) and the key declared on-chain (new_owner_authority)
   // are now required to be the same key.
+  //
+  // The inner key_auths entry must be a real 2-tuple (Array.isArray). An
+  // object-map `{0: STM…, 1: 1}` satisfies JS index reads but is dropped by
+  // steem-js authorityMapEntries, which would let a malformed payload past
+  // this gate and into the CONVEYOR signing call.
   const auth = body.new_owner_authority;
+  const firstKeyAuth = auth.key_auths?.[0];
   const authValid =
     auth.weight_threshold === 1 &&
     Array.isArray(auth.account_auths) &&
     auth.account_auths.length === 0 &&
     Array.isArray(auth.key_auths) &&
     auth.key_auths.length === 1 &&
-    auth.key_auths[0]![0] === body.new_owner_key &&
-    auth.key_auths[0]![1] === 1;
+    Array.isArray(firstKeyAuth) &&
+    firstKeyAuth.length === 2 &&
+    firstKeyAuth[0] === body.new_owner_key &&
+    firstKeyAuth[1] === 1;
   if (!authValid) {
     return NextResponse.json(
       { status: 'error', error: 'Invalid new owner authority' },
       { status: 400 }
     );
   }
+
+  // Never forward the client object. Extra enumerable fields or serializer
+  // quirks must not reach kingdom / the chain; the CONVEYOR key only ever
+  // signs this canonical single-key authority.
+  const newOwnerAuthority = {
+    weight_threshold: 1,
+    account_auths: [] as [string, number][],
+    key_auths: [[body.new_owner_key, 1]] as [string, number][],
+  };
 
   const db = getDb();
   if (!db) {
@@ -148,7 +165,7 @@ export async function POST(request: NextRequest) {
 
     await SteemService.requestAccountRecovery({
       account_to_recover: body.account_name,
-      new_owner_authority: body.new_owner_authority,
+      new_owner_authority: newOwnerAuthority,
     });
 
     // Step 3: Mark as closed — success

--- a/src/app/api/recovery/confirm/route.ts
+++ b/src/app/api/recovery/confirm/route.ts
@@ -56,6 +56,31 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Strict whitelist for new_owner_authority (S3): this is the ONLY field
+  // that decides who owns the account on-chain after recovery, and it is
+  // signed on-chain by the server's high-value CONVEYOR key — so it must
+  // be exactly the single-key authority derived from new_owner_key.
+  // Anything else (extra keys, account_auths delegates, threshold games)
+  // is rejected before the state machine is touched.
+  // This also closes the DB/chain divergence: the key stored in arecs
+  // (new_owner_key) and the key declared on-chain (new_owner_authority)
+  // are now required to be the same key.
+  const auth = body.new_owner_authority;
+  const authValid =
+    auth.weight_threshold === 1 &&
+    Array.isArray(auth.account_auths) &&
+    auth.account_auths.length === 0 &&
+    Array.isArray(auth.key_auths) &&
+    auth.key_auths.length === 1 &&
+    auth.key_auths[0]![0] === body.new_owner_key &&
+    auth.key_auths[0]![1] === 1;
+  if (!authValid) {
+    return NextResponse.json(
+      { status: 'error', error: 'Invalid new owner authority' },
+      { status: 400 }
+    );
+  }
+
   const db = getDb();
   if (!db) {
     return NextResponse.json(

--- a/tests/unit/recovery-confirm-route.test.ts
+++ b/tests/unit/recovery-confirm-route.test.ts
@@ -95,6 +95,7 @@ describe('POST /api/recovery/confirm', () => {
   it('returns ok for valid confirmed recovery (atomic CAS)', async () => {
     setupUpdateMocks({ affectedRows: 1 });
 
+    const { SteemService } = await import('@/lib/steem/server');
     const req = makeRequest(validPayload);
     const res = await POST(req);
     const data = await res.json();
@@ -102,6 +103,14 @@ describe('POST /api/recovery/confirm', () => {
     expect(data.status).toBe('ok');
     expect(res.status).toBe(200);
     expect(mockUpdateFn).toHaveBeenCalledTimes(2);
+    expect(SteemService.requestAccountRecovery).toHaveBeenCalledWith({
+      account_to_recover: 'alice',
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [[VALID_KEY_B, 1]],
+      },
+    });
   });
 
   it('short-circuits when CSRF verification fails', async () => {
@@ -205,6 +214,65 @@ describe('POST /api/recovery/confirm', () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid new owner authority');
+  });
+
+  it('S3: rejects key_auths weight other than 1', async () => {
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [[VALID_KEY_B, 0]],
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid new owner authority');
+    expect(mockUpdateFn).not.toHaveBeenCalled();
+  });
+
+  it('S3: rejects object-map inner key_auths entry (serializer mismatch)', async () => {
+    // `{0: STM…, 1: 1}` satisfies JS index reads but is dropped by
+    // steem-js authorityMapEntries (requires Array.isArray(entry)).
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [{ 0: VALID_KEY_B, 1: 1 }],
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid new owner authority');
+    expect(mockUpdateFn).not.toHaveBeenCalled();
+  });
+
+  it('S3: signs a server-constructed canonical authority (strips extra fields)', async () => {
+    setupUpdateMocks({ affectedRows: 1 });
+
+    const { SteemService } = await import('@/lib/steem/server');
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        ...validPayload.new_owner_authority,
+        extra_field: 'must-not-reach-conveyor',
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const forwarded = vi.mocked(SteemService.requestAccountRecovery).mock.calls[0]?.[0];
+    expect(forwarded).toEqual({
+      account_to_recover: 'alice',
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [[VALID_KEY_B, 1]],
+      },
+    });
+    expect(forwarded?.new_owner_authority).not.toHaveProperty('extra_field');
   });
 
   it('S3: rejects multiple key_auths entries', async () => {

--- a/tests/unit/recovery-confirm-route.test.ts
+++ b/tests/unit/recovery-confirm-route.test.ts
@@ -159,6 +159,97 @@ describe('POST /api/recovery/confirm', () => {
     expect(data.error).toBe('Invalid owner key format');
   });
 
+  // ---- S3: new_owner_authority whitelist ----
+  // The authority is signed on-chain by the server's CONVEYOR key; it must
+  // be exactly the single-key authority derived from new_owner_key.
+
+  it('S3: rejects key_auths that does not match new_owner_key (DB/chain divergence)', async () => {
+    // The audit PoC: authority declares a DIFFERENT key than the one stored
+    // in arecs — previously both were accepted and diverged silently.
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [[VALID_KEY_A, 1]], // VALID_KEY_A != new_owner_key (VALID_KEY_B)
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe('Invalid new owner authority');
+  });
+
+  it('S3: rejects non-empty account_auths (delegation to third-party accounts)', async () => {
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [['attacker', 1]],
+        key_auths: [[VALID_KEY_B, 1]],
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid new owner authority');
+  });
+
+  it('S3: rejects weight_threshold other than 1', async () => {
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 0, // the audit PoC value
+        account_auths: [],
+        key_auths: [[VALID_KEY_B, 1]],
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('S3: rejects multiple key_auths entries', async () => {
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [
+          [VALID_KEY_B, 1],
+          [VALID_KEY_A, 1],
+        ],
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('S3: rejects empty key_auths', async () => {
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [],
+        key_auths: [],
+      },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('S3: authority validation rejects BEFORE the CAS claim (no state touched)', async () => {
+    const req = makeRequest({
+      ...validPayload,
+      new_owner_authority: {
+        weight_threshold: 1,
+        account_auths: [['attacker', 1]],
+        key_auths: [[VALID_KEY_B, 1]],
+      },
+    });
+    await POST(req);
+    // The CAS update must never have run for a malformed authority.
+    expect(mockUpdateFn).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when atomic update claims 0 rows (already processed / not found)', async () => {
     setupUpdateMocks({ affectedRows: 0 });
 


### PR DESCRIPTION
## Summary

Fixes audit finding **S3** (MEDIUM, the last medium-severity item from the 2026-08-04 audit): `new_owner_authority` — the only field deciding on-chain ownership after recovery, **signed on-chain by the server's CONVEYOR key** — was passed through with no validation, and never cross-checked against the stored `new_owner_key`.

## The vulnerability

Validation strength in the same payload was wildly inconsistent: `code` got a 20-hex regex, both owner keys got strict STM-base58 regexes, but the authority object got **nothing**. Two defects:

1. **Arbitrary authority to the CONVEYOR signing call** — the security team's vitest PoC confirmed `weight_threshold: 0` + `account_auths` pointing at a third-party account was accepted verbatim and passed to `requestAccountRecovery`.
2. **DB/chain divergence** — `new_owner_key` is what gets stored in `arecs`; `new_owner_authority.key_auths` is what goes on-chain. They were never compared (PoC: DIVERGENCE: YES).

## Fix

Strict whitelist, checked **before the CAS claim** so malformed payloads never touch the state machine:

```
weight_threshold === 1
account_auths     === []          (no third-party delegation)
key_auths.length  === 1
key_auths[0][0]   === new_owner_key   (closes the divergence)
key_auths[0][1]   === 1
```

This matches exactly what the legitimate client constructs (the confirmation page derives a single-key authority from the new password) — no client change needed.

## Test plan

- [x] 6 new cases: divergence PoC regression, `account_auths` delegation, threshold games, multi-key, empty `key_auths`, and validation-before-CAS ordering (no state touched on reject)
- [x] Existing success-path tests unchanged (legit payload already conformant)
- [x] `pnpm type-check` / `pnpm lint` — clean
- [x] `pnpm test` — 483 passed