### PR TITLE
fix(security): audit S6/S7 — forensic IP via getClientIP, analytics log bounds

### DIFF
--- a/src/app/api/analytics/event/route.ts
+++ b/src/app/api/analytics/event/route.ts
@@ -9,6 +9,12 @@ interface AnalyticsEventBody {
   timestamp?: string;
 }
 
+// S7: bounds on unauthenticated (CSRF-token-only) log writes — without them
+// an attacker can push arbitrary-size lines into the server log.
+const MAX_EVENT_NAME = 64;
+const MAX_PROPERTIES_BYTES = 2048;
+const MAX_PROPERTY_KEYS = 16;
+
 export async function POST(request: NextRequest) {
   try {
     // CSRF: analytics is a write endpoint (logs), so require a token to prevent
@@ -26,9 +32,27 @@ export async function POST(request: NextRequest) {
     const body = await request.json() as AnalyticsEventBody;
     const { event, properties = {}, timestamp } = body;
 
-    if (!event) {
+    if (!event || typeof event !== 'string') {
       return NextResponse.json(
         { error: 'Missing event name' },
+        { status: 400 }
+      );
+    }
+
+    // S7: length/format caps on the event name and property payload before
+    // they reach the log sink.
+    if (event.length > MAX_EVENT_NAME || !/^[\w.:-]+$/.test(event)) {
+      return NextResponse.json(
+        { error: 'Invalid event name' },
+        { status: 400 }
+      );
+    }
+    if (
+      Object.keys(properties).length > MAX_PROPERTY_KEYS ||
+      JSON.stringify(properties).length > MAX_PROPERTIES_BYTES
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid properties' },
         { status: 400 }
       );
     }

--- a/src/app/api/recovery/request/route.ts
+++ b/src/app/api/recovery/request/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { eq, and } from 'drizzle-orm';
-import { verifyCSRF, rateLimit } from '@/lib/middleware';
+import { verifyCSRF, rateLimit, getClientIP } from '@/lib/middleware';
 import { getDb } from '@/lib/db';
 import { arecs } from '@/lib/db/schema';
 
@@ -70,11 +70,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ status: 'duplicate' });
     }
 
-    // Extract client IP
-    const remoteIp =
-      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-      request.headers.get('x-real-ip') ||
-      null;
+    // Extract client IP for forensics: reuse the proxy-aware getClientIP()
+    // (TRUST_PROXY_COUNT-aware) instead of trusting the client-controlled
+    // first X-Forwarded-For entry — arecs.remote_ip is the evidence
+    // operators rely on when reviewing recovery requests.
+    const resolvedIp = getClientIP(request);
+    const remoteIp = resolvedIp === 'unknown' ? null : resolvedIp;
 
     // Insert new recovery request
     await db.insert(arecs).values({

--- a/src/lib/middleware/index.ts
+++ b/src/lib/middleware/index.ts
@@ -1,5 +1,5 @@
 // Security middleware exports
 export { verifyCSRF, generateCSRFToken, setCSRFToken, createCSRFResponse } from './csrf';
-export { rateLimit, rateLimitByUser } from './rate-limit';
+export { rateLimit, rateLimitByUser, getClientIP } from './rate-limit';
 export type { RateLimitConfig } from './rate-limit';
 export { setCacheInvalidateHeader } from './cache-invalidate';

--- a/src/lib/middleware/rate-limit.ts
+++ b/src/lib/middleware/rate-limit.ts
@@ -60,7 +60,7 @@ let warnedMissingProxyConfig = false;
  *    when an operator forgets to set TRUST_PROXY_COUNT.
  * 3. Neither available: 'unknown' (all clients share one bucket — degraded).
  */
-function getClientIP(request: NextRequest): string {
+export function getClientIP(request: NextRequest): string {
   const trustedHops = getTrustedProxyCount();
   if (trustedHops !== null && trustedHops > 0) {
     const xff = request.headers.get('x-forwarded-for');

--- a/tests/unit/analytics-event-route.test.ts
+++ b/tests/unit/analytics-event-route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock middleware
+vi.mock('@/lib/middleware', () => ({
+  verifyCSRF: vi.fn().mockResolvedValue(null),
+  rateLimit: vi.fn().mockResolvedValue(null),
+  getClientIP: vi.fn().mockReturnValue('unknown'),
+}));
+
+import { POST } from '@/app/api/analytics/event/route';
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/analytics/event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': 't' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/analytics/event (S7 bounds)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('accepts a normal event', async () => {
+    const res = await POST(makeRequest({ event: 'page_view', properties: { page: '/x' } }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(console.log).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an event name longer than 64 chars', async () => {
+    const res = await POST(makeRequest({ event: 'a'.repeat(65) }));
+    expect(res.status).toBe(400);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('rejects event names with unexpected characters', async () => {
+    const res = await POST(makeRequest({ event: 'bad event\nname' }));
+    expect(res.status).toBe(400);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('rejects properties over 2048 bytes', async () => {
+    const res = await POST(makeRequest({ event: 'page_view', properties: { blob: 'x'.repeat(3000) } }));
+    expect(res.status).toBe(400);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('rejects properties with more than 16 keys', async () => {
+    const properties: Record<string, number> = {};
+    for (let i = 0; i < 17; i++) properties[`k${i}`] = i;
+    const res = await POST(makeRequest({ event: 'page_view', properties }));
+    expect(res.status).toBe(400);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing/non-string event name', async () => {
+    const res = await POST(makeRequest({ event: 123 }));
+    expect(res.status).toBe(400);
+    expect(console.log).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/recovery-request-route.test.ts
+++ b/tests/unit/recovery-request-route.test.ts
@@ -6,6 +6,8 @@ import { NextRequest } from 'next/server';
 vi.mock('@/lib/middleware', () => ({
   verifyCSRF: vi.fn().mockResolvedValue(null),
   rateLimit: vi.fn().mockResolvedValue(null),
+  // Proxy-aware IP resolution used for the forensic remote_ip field.
+  getClientIP: vi.fn().mockReturnValue('9.9.9.9'),
 }));
 
 // Mock the Drizzle db module
@@ -62,6 +64,30 @@ describe('POST /api/recovery/request', () => {
     expect(mockFindFirst).toHaveBeenCalledOnce();
     expect(mockInsert).toHaveBeenCalledOnce();
     expect(mockInsertValues).toHaveBeenCalledOnce();
+  });
+
+  it('S6: forensic remote_ip comes from the proxy-aware getClientIP, not raw XFF', async () => {
+    // The request carries a SPOOFED x-forwarded-for; the recorded IP must
+    // come from the (mocked) proxy-aware resolver instead.
+    const req = new NextRequest('http://localhost/api/recovery/request', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': 'test-token',
+        'x-forwarded-for': '1.2.3.4, 6.6.6.6',
+      },
+      body: JSON.stringify({
+        contact_email: 'test@example.com',
+        account_name: 'alice',
+        owner_key: VALID_OWNER_KEY,
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const inserted = mockInsertValues.mock.calls[0]![0] as { remoteIp: string | null };
+    expect(inserted.remoteIp).toBe('9.9.9.9'); // from getClientIP mock
+    expect(inserted.remoteIp).not.toContain('1.2.3.4');
   });
 
   it('returns duplicate for existing open request', async () => {


### PR DESCRIPTION
## Summary

Closes the **last two findings** from the 2026-08-04 audit (both LOW).

### S6 — forensic IP from the client-controlled XFF first entry

`recovery/request` recorded `arecs.remote_ip` from the raw first `X-Forwarded-For` entry (fully client-spoofable), while the proxy-aware `getClientIP()` (TRUST_PROXY_COUNT-aware, added in #308) already existed — two competing IP semantics in one repo. `arecs.remote_ip` is the evidence operators rely on when reviewing recovery requests.

Fix: export `getClientIP` from the middleware index and reuse it; the `'unknown'` fallback degrades to `null` in the record.

### S7 — unbounded attacker data into the analytics log

`/api/analytics/event` accepted arbitrary-size log lines (event name only checked non-empty; properties unbounded). The CSRF token is freely obtainable, so this is effectively unauthenticated.

Fix: caps before the log sink — event name ≤64 chars with a word-char format check; properties ≤16 keys and ≤2048 bytes serialized.

## Test plan

- [x] S6: spoofed XFF must not reach the record (IP comes from the resolver) — new route test
- [x] S7: 6 new route cases (normal, overlong name, bad characters, oversized properties, too many keys, non-string name)
- [x] `pnpm type-check` / `pnpm lint` — clean
- [x] `pnpm test` — 493 passed