### PR TITLE
feat(security): make auth challenge rate limit configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ STEEM_RPC_URL=https://api.steemit.com
 # Optional: Rate limiting (Redis-backed when REDIS_URL is set; per-process
 # in-memory fallback otherwise — not shared across instances).
 # RATE_LIMIT_ALLOW_MEMORY_FALLBACK=false  # reject (503) instead of falling back
+# Per-route limits (defaults shown; unset or invalid values use the default):
+# RATE_LIMIT_AUTH_CHALLENGE_MAX=10      # login challenge requests per window
+# RATE_LIMIT_AUTH_CHALLENGE_WINDOW=60   # window length in seconds
 
 # Number of trusted reverse-proxy hops in front of this app (ELB/OpenResty).
 # Set this so rate limiting keys on the real client IP rather than a spoofable

--- a/src/app/api/auth/challenge/route.ts
+++ b/src/app/api/auth/challenge/route.ts
@@ -2,7 +2,7 @@
 // Generate a login challenge for the user
 import { NextRequest, NextResponse } from 'next/server';
 import { SteemService } from '@/lib/steem/server';
-import { setCSRFToken, rateLimit, rateLimitByUser } from '@/lib/middleware';
+import { setCSRFToken, rateLimit, rateLimitByUser, rateLimitConfigFromEnv } from '@/lib/middleware';
 import { getRedis, redisKey } from '@/lib/cache/redis';
 
 const CHALLENGE_TTL = 300; // 5 minutes
@@ -33,16 +33,15 @@ export async function GET(request: NextRequest) {
     //  - per-username: an attacker hammering challenges for one victim
     //    otherwise overwrites the victim's challenge on every attempt,
     //    locking them out of login (targeted auth DoS).
-    const ipLimit = await rateLimit(request, 'auth_challenge', {
+    // Tunable via RATE_LIMIT_AUTH_CHALLENGE_MAX / _WINDOW (see .env.example).
+    const limitConfig = rateLimitConfigFromEnv('RATE_LIMIT_AUTH_CHALLENGE', {
       maxRequests: 10,
       windowSeconds: 60,
     });
+    const ipLimit = await rateLimit(request, 'auth_challenge', limitConfig);
     if (ipLimit) return ipLimit;
 
-    const userLimit = await rateLimitByUser(username, 'auth_challenge', {
-      maxRequests: 10,
-      windowSeconds: 60,
-    });
+    const userLimit = await rateLimitByUser(username, 'auth_challenge', limitConfig);
     if (userLimit) return userLimit;
 
     // Generate challenge

--- a/src/lib/middleware/index.ts
+++ b/src/lib/middleware/index.ts
@@ -1,5 +1,5 @@
 // Security middleware exports
 export { verifyCSRF, generateCSRFToken, setCSRFToken, createCSRFResponse } from './csrf';
-export { rateLimit, rateLimitByUser, getClientIP } from './rate-limit';
+export { rateLimit, rateLimitByUser, getClientIP, rateLimitConfigFromEnv } from './rate-limit';
 export type { RateLimitConfig } from './rate-limit';
 export { setCacheInvalidateHeader } from './cache-invalidate';

--- a/src/lib/middleware/rate-limit.ts
+++ b/src/lib/middleware/rate-limit.ts
@@ -168,6 +168,26 @@ function memoryRateLimit(
   return null;
 }
 
+/**
+ * Build a RateLimitConfig from environment variables so limits can be tuned
+ * at deploy time without a code change. Convention: `<PREFIX>_MAX` is the
+ * max requests per window and `<PREFIX>_WINDOW` the window length in
+ * seconds; unset or non-positive values fall back to `defaults`.
+ */
+export function rateLimitConfigFromEnv(
+  prefix: string,
+  defaults: RateLimitConfig
+): RateLimitConfig {
+  const max = Number(process.env[`${prefix}_MAX`]);
+  const window = Number(process.env[`${prefix}_WINDOW`]);
+  return {
+    maxRequests:
+      Number.isInteger(max) && max > 0 ? max : defaults.maxRequests,
+    windowSeconds:
+      Number.isInteger(window) && window > 0 ? window : defaults.windowSeconds,
+  };
+}
+
 // Whether to allow a memory fallback when Redis is not configured. In a
 // single-instance deploy this is fine; multi-instance deploys should set
 // REDIS_URL (and leave this enabled purely for the Redis-error transient case).

--- a/tests/unit/auth-challenge-route.test.ts
+++ b/tests/unit/auth-challenge-route.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
-// Mock middleware — rate limiting is the security behavior under test
+// Mock middleware — rate limiting is the security behavior under test.
+// rateLimitConfigFromEnv keeps its real implementation (via importOriginal)
+// so the env-override behavior is exercised end to end.
 const mockRateLimit = vi.fn();
 const mockRateLimitByUser = vi.fn();
-vi.mock('@/lib/middleware', () => ({
-  setCSRFToken: vi.fn(),
-  rateLimit: (...args: unknown[]) => mockRateLimit(...args),
-  rateLimitByUser: (...args: unknown[]) => mockRateLimitByUser(...args),
-  verifyCSRF: vi.fn(),
-}));
+vi.mock('@/lib/middleware', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/middleware')>();
+  return {
+    ...actual,
+    setCSRFToken: vi.fn(),
+    rateLimit: (...args: unknown[]) => mockRateLimit(...args),
+    rateLimitByUser: (...args: unknown[]) => mockRateLimitByUser(...args),
+    verifyCSRF: vi.fn(),
+  };
+});
 
 // Mock SteemService
 const mockGenerateChallenge = vi.fn();
@@ -37,6 +43,8 @@ function makeRequest(username?: string): NextRequest {
 describe('GET /api/auth/challenge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.RATE_LIMIT_AUTH_CHALLENGE_MAX;
+    delete process.env.RATE_LIMIT_AUTH_CHALLENGE_WINDOW;
     mockRateLimit.mockResolvedValue(null);
     mockRateLimitByUser.mockResolvedValue(null);
     mockGenerateChallenge.mockReturnValue('login-alice-123-abc');
@@ -108,5 +116,31 @@ describe('GET /api/auth/challenge', () => {
       maxRequests: 10,
       windowSeconds: 60,
     });
+  });
+
+  it('honours RATE_LIMIT_AUTH_CHALLENGE_MAX / _WINDOW overrides', async () => {
+    process.env.RATE_LIMIT_AUTH_CHALLENGE_MAX = '3';
+    process.env.RATE_LIMIT_AUTH_CHALLENGE_WINDOW = '120';
+    await GET(makeRequest('alice'));
+    expect(mockRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'auth_challenge',
+      { maxRequests: 3, windowSeconds: 120 }
+    );
+    expect(mockRateLimitByUser).toHaveBeenCalledWith('alice', 'auth_challenge', {
+      maxRequests: 3,
+      windowSeconds: 120,
+    });
+  });
+
+  it('falls back to defaults when the env overrides are invalid', async () => {
+    process.env.RATE_LIMIT_AUTH_CHALLENGE_MAX = 'abc';
+    process.env.RATE_LIMIT_AUTH_CHALLENGE_WINDOW = '0';
+    await GET(makeRequest('alice'));
+    expect(mockRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'auth_challenge',
+      { maxRequests: 10, windowSeconds: 60 }
+    );
   });
 });

--- a/tests/unit/rate-limit-proxy.test.ts
+++ b/tests/unit/rate-limit-proxy.test.ts
@@ -10,7 +10,7 @@ vi.mock('@/lib/cache/redis', () => ({
   cacheDeleteByPrefix: vi.fn(),
 }));
 
-import { rateLimit, rateLimitByUser } from '@/lib/middleware/rate-limit';
+import { rateLimit, rateLimitByUser, rateLimitConfigFromEnv } from '@/lib/middleware/rate-limit';
 
 function makeReq(headers: Record<string, string> = {}, path = '/api/broadcast/transfer'): NextRequest {
   const url = new URL(`http://localhost${path}`);
@@ -249,4 +249,36 @@ describe('rateLimitByUser', () => {
     expect(res!.status).toBe(503);
     delete process.env.RATE_LIMIT_ALLOW_MEMORY_FALLBACK;
   });
+});
+
+describe('rateLimitConfigFromEnv', () => {
+  const PREFIX = 'RATE_LIMIT_TEST_ENVCFG';
+  const defaults = { maxRequests: 10, windowSeconds: 60 };
+
+  afterEach(() => {
+    delete process.env[`${PREFIX}_MAX`];
+    delete process.env[`${PREFIX}_WINDOW`];
+  });
+
+  it('returns defaults when env vars are unset', () => {
+    expect(rateLimitConfigFromEnv(PREFIX, defaults)).toEqual(defaults);
+  });
+
+  it('honours valid overrides', () => {
+    process.env[`${PREFIX}_MAX`] = '3';
+    process.env[`${PREFIX}_WINDOW`] = '120';
+    expect(rateLimitConfigFromEnv(PREFIX, defaults)).toEqual({
+      maxRequests: 3,
+      windowSeconds: 120,
+    });
+  });
+
+  it.each(['abc', '0', '-5', '1.5', ''])(
+    'falls back to defaults for invalid value %p',
+    (value) => {
+      process.env[`${PREFIX}_MAX`] = value;
+      process.env[`${PREFIX}_WINDOW`] = value;
+      expect(rateLimitConfigFromEnv(PREFIX, defaults)).toEqual(defaults);
+    }
+  );
 });


### PR DESCRIPTION
## Why

Found during the 2026-08-04 audit remediation re-review: the `/api/auth/challenge` rate limits added in #315 (F6/S2) are hardcoded at 10/min for both dimensions (per-IP and per-username), with no way to tune them at deploy time.

## What

- New generic helper `rateLimitConfigFromEnv(prefix, defaults)` in `src/lib/middleware/rate-limit.ts` — reads `<PREFIX>_MAX` / `<PREFIX>_WINDOW`, falling back to the given defaults when unset or invalid (non-integer / non-positive). Reusable by other routes later.
- `challenge/route.ts` now sources both limit checks from `RATE_LIMIT_AUTH_CHALLENGE_MAX` / `RATE_LIMIT_AUTH_CHALLENGE_WINDOW`, defaults 10 / 60s — **behavior is unchanged without configuration**.
- `.env.example` documents the new variables.

## Tests

- `auth-challenge-route.test.ts`: middleware mock now spreads `importOriginal` so the real helper is exercised; new cases for env override (3/120s) and invalid-value fallback; env cleared in `beforeEach`.
- `rate-limit-proxy.test.ts`: direct unit tests for `rateLimitConfigFromEnv` — defaults, valid override, parametrized invalid values (`abc`, `0`, `-5`, `1.5`, `''`).

## Verification

- `pnpm type-check` ✅
- `pnpm lint` ✅ (0 errors; 6 pre-existing warnings in untouched files)
- `pnpm test` ✅ 57 files / 502 tests pass (493 existing + 9 new)