### PR TITLE
fix: drop dead sidebar links, allow https images in CSP

### DIFF
--- a/src/components/layout/side-panel.tsx
+++ b/src/components/layout/side-panel.tsx
@@ -81,10 +81,7 @@ export function SidePanel({ open, onOpenChange }: SidePanelProps) {
   const resourceExternalLinks = [
     { href: SIDE_PANEL_EXTERNAL.apiDocs, label: t('navApiDocs') },
     { href: SIDE_PANEL_EXTERNAL.bluepaper, label: t('navBluepaper') },
-    { href: SIDE_PANEL_EXTERNAL.smtWhitepaper, label: t('navSmtWhitepaper') },
     { href: SIDE_PANEL_EXTERNAL.whitepaper, label: t('navWhitepaper') },
-    { href: SIDE_PANEL_EXTERNAL.jobs, label: t('navJobs') },
-    { href: SIDE_PANEL_EXTERNAL.businessCenter, label: t('navBusinessCenter') },
   ] as const;
 
   const resourceInternalLinks = [

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -539,9 +539,6 @@
     },
     "advancedRoutesNotice": "Custom withdrawal routes were configured to receive vesting payments. Please reconfirm in the Advanced Routes options.",
     "settings": "Settings",
-    "navSmtWhitepaper": "SMT Whitepaper",
-    "navJobs": "Jobs",
-    "navBusinessCenter": "Steem Business Center",
     "navSupport": "Support",
     "support": {
       "title": "Steemit Wallet Support",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -530,9 +530,6 @@
     },
     "advancedRoutesNotice": "Se configuraron rutas de retiro personalizadas para recibir los pagos de vesting. Confírmelas de nuevo en las opciones de rutas avanzadas.",
     "settings": "Configuración",
-    "navSmtWhitepaper": "Whitepaper de SMT",
-    "navJobs": "Empleo",
-    "navBusinessCenter": "Centro de negocios Steem",
     "navSupport": "Soporte",
     "support": {
       "title": "Soporte de Steemit Wallet",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -539,9 +539,6 @@
     },
     "advancedRoutesNotice": "您已配置自定义的 power down 收款路由，请在 Advanced Routes 中重新确认。",
     "settings": "设置",
-    "navSmtWhitepaper": "SMT 白皮书",
-    "navJobs": "招聘信息",
-    "navBusinessCenter": "Steem 商业中心",
     "navSupport": "支持",
     "support": {
       "title": "Steemit 钱包支持",

--- a/src/lib/navigation/side-panel-links.ts
+++ b/src/lib/navigation/side-panel-links.ts
@@ -4,10 +4,7 @@ export const SIDE_PANEL_EXTERNAL = {
   poloniex: 'https://www.poloniex.com/zh-CN/trade/STEEM_USDT?type=spot',
   apiDocs: 'https://developers.steem.io/',
   bluepaper: 'https://steem.io/steem-bluepaper.pdf',
-  smtWhitepaper: 'https://smt.steem.io/',
   whitepaper: 'https://steem.io/SteemWhitePaper.pdf',
-  jobs: 'https://jobs.lever.co/steemit',
-  businessCenter: 'https://steemeconomy.com/',
 } as const;
 
 export const SIDE_PANEL_INTERNAL = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -27,7 +27,11 @@ function buildCsp(nonce: string): string {
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${devExtras}`,
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' blob: data:",
+    // profile_image/cover_image are arbitrary URLs from on-chain metadata, so image hosts
+    // cannot be allowlisted by name; legacy allowed `imgSrc: *` for the same reason.
+    // Scheme-wide https: covers steemitimages/devimages and user URLs; http is upgraded
+    // by upgrade-insecure-requests below.
+    "img-src 'self' blob: data: https:",
     "font-src 'self'",
     "connect-src 'self'",
     "object-src 'none'",

--- a/tests/unit/proxy-csp.test.ts
+++ b/tests/unit/proxy-csp.test.ts
@@ -27,6 +27,8 @@ describe('proxy CSP nonce', () => {
     const scriptSrc = csp!.split(';').find((d) => d.trim().startsWith('script-src'))!;
     expect(scriptSrc).not.toContain("'unsafe-inline'");
     expect(csp).toContain("frame-ancestors 'none'");
+    // Arbitrary on-chain profile/cover image URLs must load (legacy parity: imgSrc '*').
+    expect(csp).toContain("img-src 'self' blob: data: https:");
   });
 
   it('generates a fresh nonce per request', () => {


### PR DESCRIPTION
Two small fixes in one PR:

1. **Side panel cleanup** — remove SMT Whitepaper / Jobs / Steem Business Center links. The destinations (smt.steem.io, jobs.lever.co/steemit, steemeconomy.com) are no longer maintained. Also removes the unused URL constants and i18n keys (en/zh/es).

2. **CSP img-src fix** — avatars (`steemitimages.com/u/<user>/avatar`) and user-controlled `profile_image`/`cover_image` URLs from on-chain metadata were blocked by `img-src 'self' blob: data:`. Since profile image hosts are arbitrary and cannot be allowlisted by name, follow legacy (`helmet imgSrc: "* data:"`) and allow any `https:` image. Plain http is still upgraded by `upgrade-insecure-requests`.

Verified: `pnpm type-check`, side-panel-links and proxy-csp unit tests (5 cases incl. a new img-src assertion).