### PR TITLE
fix(ui): stop header shifting when side panel opens

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -17,7 +17,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         <Header onOpenSidePanel={() => setSidePanelOpen(true)} />
         <DegradationBanner />
         <SidePanel open={sidePanelOpen} onOpenChange={setSidePanelOpen} />
-        <main className="pt-16">{children}</main>
+        <main>{children}</main>
       </div>
     </TooltipProvider>
   );

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -64,7 +64,11 @@ export function Header({ onOpenSidePanel }: HeaderProps) {
   return (
     <header
       className={cn(
-        'fixed inset-x-0 top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'
+        // Sticky (not fixed) so the header stays in document flow: Radix's scroll lock
+        // compensates the removed scrollbar with body padding-right, which fixed
+        // (viewport-relative) elements ignore — that made the header jump sideways
+        // whenever the side panel or login dialog opened.
+        'sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60'
       )}
     >
       <nav className="flex h-16 items-center px-4 md:px-6">


### PR DESCRIPTION
Opening the right side panel (or any Radix dialog) hides the page scrollbar and compensates with `padding-right` on `<body>`. That compensation only applies to in-flow elements — the header was `position: fixed` (viewport-relative), so it ignored the padding and visibly jumped sideways on every open/close.

Fix: switch the header to `sticky top-0` (same approach as condenser's Header) so it participates in the body compensation, and drop the `pt-16` spacer on `<main>` that only existed to clear the fixed header.

Verified: `pnpm type-check` + all 528 unit tests pass; no other code depends on the fixed offset.