### PR TITLE
fix(telemetry): drop Next.js health-probe spans before OTLP export

### DIFF
--- a/src/lib/telemetry/filter-processor.ts
+++ b/src/lib/telemetry/filter-processor.ts
@@ -1,0 +1,93 @@
+/**
+ * SpanProcessor that drops health-probe spans (and their descendants) before
+ * they reach the OTLP exporter.
+ *
+ * HttpInstrumentation already skips creating the outer HTTP server span for
+ * /api/health and /.well-known/healthcheck.json, but Next.js still emits
+ * framework spans for those routes. Without this filter they dominate OpenObserve.
+ */
+
+import type { Context } from '@opentelemetry/api';
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+
+import { shouldDropHealthSpan } from './ignore';
+
+/** Cap remembered drop markers so a long-running process cannot grow unbounded. */
+const DEFAULT_MAX_MARKERS = 4096;
+
+export type FilteringSpanProcessorOptions = {
+  /** Max span/trace IDs to remember for descendant dropping. */
+  maxMarkers?: number;
+};
+
+export class FilteringSpanProcessor implements SpanProcessor {
+  private readonly droppedSpanIds = new Set<string>();
+  private readonly droppedTraceIds = new Set<string>();
+  private readonly markerOrder: string[] = [];
+  private readonly maxMarkers: number;
+
+  constructor(
+    private readonly delegate: SpanProcessor,
+    options: FilteringSpanProcessorOptions = {}
+  ) {
+    this.maxMarkers = options.maxMarkers ?? DEFAULT_MAX_MARKERS;
+  }
+
+  forceFlush(): Promise<void> {
+    return this.delegate.forceFlush();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    this.delegate.onStart(span, parentContext);
+  }
+
+  onEnding(span: Span): void {
+    this.delegate.onEnding?.(span);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const ctx = span.spanContext();
+    const parentId = span.parentSpanContext?.spanId;
+    const drop =
+      shouldDropHealthSpan(span.name, span.attributes as Record<string, unknown>) ||
+      (parentId !== undefined && this.droppedSpanIds.has(parentId)) ||
+      this.droppedTraceIds.has(ctx.traceId);
+
+    if (drop) {
+      this.rememberDrop(ctx.spanId, ctx.traceId);
+      return;
+    }
+
+    this.delegate.onEnd(span);
+  }
+
+  shutdown(): Promise<void> {
+    this.droppedSpanIds.clear();
+    this.droppedTraceIds.clear();
+    this.markerOrder.length = 0;
+    return this.delegate.shutdown();
+  }
+
+  private rememberDrop(spanId: string, traceId: string): void {
+    this.addMarker(this.droppedSpanIds, `s:${spanId}`);
+    this.addMarker(this.droppedTraceIds, `t:${traceId}`);
+  }
+
+  private addMarker(set: Set<string>, key: string): void {
+    const bare = key.slice(2);
+    if (set.has(bare)) return;
+    set.add(bare);
+    this.markerOrder.push(key);
+    while (this.markerOrder.length > this.maxMarkers) {
+      const oldest = this.markerOrder.shift();
+      if (!oldest) break;
+      const id = oldest.slice(2);
+      if (oldest.startsWith('s:')) this.droppedSpanIds.delete(id);
+      else this.droppedTraceIds.delete(id);
+    }
+  }
+}

--- a/src/lib/telemetry/ignore.ts
+++ b/src/lib/telemetry/ignore.ts
@@ -4,11 +4,25 @@
  * Health probes (ELB / OpenResty / Docker HEALTHCHECK) would otherwise dominate
  * the trace stream. Outgoing calls to the OTLP collector must be ignored to
  * prevent an export-loop of traces about traces.
+ *
+ * Node `HttpInstrumentation.ignoreIncomingRequestHook` only skips the outer
+ * HTTP server span. Next.js still emits framework spans (`HEAD /api/health`,
+ * `executing api route (app) /api/health`, middleware, etc.). Those are dropped
+ * in the FilteringSpanProcessor via {@link shouldDropHealthSpan}.
  */
 
 export const IGNORED_INCOMING_PATHS = [
   '/api/health',
   '/.well-known/healthcheck.json',
+] as const;
+
+/** Attribute keys that may carry the request path on HTTP / Next spans. */
+const PATH_ATTRIBUTE_KEYS = [
+  'http.target',
+  'url.path',
+  'http.route',
+  'http.url',
+  'url.full',
 ] as const;
 
 export function incomingPathname(url: string | undefined): string {
@@ -27,6 +41,40 @@ export function incomingPathname(url: string | undefined): string {
 export function shouldIgnoreIncomingPath(url: string | undefined): boolean {
   const path = incomingPathname(url);
   return IGNORED_INCOMING_PATHS.some((ignored) => path === ignored);
+}
+
+/**
+ * Extract a pathname from span attributes (legacy `http.target` or stable
+ * `url.path` / `http.route`). Returns '' when none are present.
+ */
+export function pathFromSpanAttributes(
+  attributes: Record<string, unknown> | undefined
+): string {
+  if (!attributes) return '';
+  for (const key of PATH_ATTRIBUTE_KEYS) {
+    const value = attributes[key];
+    if (typeof value !== 'string' || !value) continue;
+    const path = incomingPathname(value);
+    if (path) return path;
+  }
+  return '';
+}
+
+/**
+ * True when a finished span is a health probe (by path attribute or span name).
+ * Used by the filtering processor so Next.js internal spans do not fill OO.
+ */
+export function shouldDropHealthSpan(
+  name: string,
+  attributes: Record<string, unknown> | undefined
+): boolean {
+  if (shouldIgnoreIncomingPath(pathFromSpanAttributes(attributes))) {
+    return true;
+  }
+  for (const ignored of IGNORED_INCOMING_PATHS) {
+    if (name.includes(ignored)) return true;
+  }
+  return false;
 }
 
 function defaultPort(protocol: string, port: string): string {

--- a/src/lib/telemetry/register.ts
+++ b/src/lib/telemetry/register.ts
@@ -32,6 +32,7 @@ import {
   loadTelemetryConfig,
   type TelemetryConfig,
 } from './config';
+import { FilteringSpanProcessor } from './filter-processor';
 import {
   shouldIgnoreIncomingPath,
   shouldIgnoreOutgoingFetch,
@@ -117,9 +118,15 @@ function startSdk(config: TelemetryConfig): void {
     exporterOptions.headers = config.headers;
   }
 
+  // Filter health-probe spans (Next.js internals bypass HttpInstrumentation
+  // ignoreIncomingRequestHook) before batching/export.
   const nextProvider = new NodeTracerProvider({
     resource: buildResource(config),
-    spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter(exporterOptions))],
+    spanProcessors: [
+      new FilteringSpanProcessor(
+        new BatchSpanProcessor(new OTLPTraceExporter(exporterOptions))
+      ),
+    ],
   });
 
   nextProvider.register({

--- a/tests/unit/telemetry-filter-processor.test.ts
+++ b/tests/unit/telemetry-filter-processor.test.ts
@@ -35,9 +35,7 @@ function makeSpan(opts: {
   } as unknown as ReadableSpan;
 }
 
-function mockDelegate(): SpanProcessor & {
-  onEnd: ReturnType<typeof vi.fn>;
-} {
+function mockDelegate() {
   return {
     onStart: vi.fn(),
     onEnd: vi.fn(),
@@ -50,7 +48,9 @@ function mockDelegate(): SpanProcessor & {
 describe('FilteringSpanProcessor', () => {
   it('forwards business spans to the delegate', () => {
     const delegate = mockDelegate();
-    const processor = new FilteringSpanProcessor(delegate);
+    const processor = new FilteringSpanProcessor(
+      delegate as unknown as SpanProcessor
+    );
     const span = makeSpan({
       name: 'GET',
       spanId: '1111111111111111',
@@ -62,7 +62,9 @@ describe('FilteringSpanProcessor', () => {
 
   it('drops health spans identified by http.target', () => {
     const delegate = mockDelegate();
-    const processor = new FilteringSpanProcessor(delegate);
+    const processor = new FilteringSpanProcessor(
+      delegate as unknown as SpanProcessor
+    );
     processor.onEnd(
       makeSpan({
         name: 'GET',
@@ -75,7 +77,9 @@ describe('FilteringSpanProcessor', () => {
 
   it('drops Next.js spans that name the health route', () => {
     const delegate = mockDelegate();
-    const processor = new FilteringSpanProcessor(delegate);
+    const processor = new FilteringSpanProcessor(
+      delegate as unknown as SpanProcessor
+    );
     processor.onEnd(
       makeSpan({
         name: 'HEAD /api/health',
@@ -93,7 +97,9 @@ describe('FilteringSpanProcessor', () => {
 
   it('drops descendants of a dropped health span (same parent)', () => {
     const delegate = mockDelegate();
-    const processor = new FilteringSpanProcessor(delegate);
+    const processor = new FilteringSpanProcessor(
+      delegate as unknown as SpanProcessor
+    );
     const parentId = '5555555555555555';
     processor.onEnd(
       makeSpan({
@@ -115,7 +121,9 @@ describe('FilteringSpanProcessor', () => {
 
   it('drops later spans on a dropped health trace even without parent link', () => {
     const delegate = mockDelegate();
-    const processor = new FilteringSpanProcessor(delegate);
+    const processor = new FilteringSpanProcessor(
+      delegate as unknown as SpanProcessor
+    );
     const traceId = 'cccccccccccccccccccccccccccccccc';
     processor.onEnd(
       makeSpan({
@@ -137,7 +145,9 @@ describe('FilteringSpanProcessor', () => {
 
   it('forwards onStart / forceFlush / shutdown to the delegate', async () => {
     const delegate = mockDelegate();
-    const processor = new FilteringSpanProcessor(delegate);
+    const processor = new FilteringSpanProcessor(
+      delegate as unknown as SpanProcessor
+    );
     const span = {} as Span;
     const ctx = {} as Context;
     processor.onStart(span, ctx);

--- a/tests/unit/telemetry-filter-processor.test.ts
+++ b/tests/unit/telemetry-filter-processor.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Context } from '@opentelemetry/api';
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+import { FilteringSpanProcessor } from '@/lib/telemetry/filter-processor';
+
+function makeSpan(opts: {
+  name: string;
+  spanId: string;
+  traceId?: string;
+  parentSpanId?: string;
+  attributes?: Record<string, unknown>;
+}): ReadableSpan {
+  const traceId = opts.traceId ?? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  return {
+    name: opts.name,
+    attributes: opts.attributes ?? {},
+    spanContext: () => ({
+      traceId,
+      spanId: opts.spanId,
+      traceFlags: 1,
+    }),
+    ...(opts.parentSpanId
+      ? {
+          parentSpanContext: {
+            traceId,
+            spanId: opts.parentSpanId,
+            traceFlags: 1,
+          },
+        }
+      : {}),
+  } as unknown as ReadableSpan;
+}
+
+function mockDelegate(): SpanProcessor & {
+  onEnd: ReturnType<typeof vi.fn>;
+} {
+  return {
+    onStart: vi.fn(),
+    onEnd: vi.fn(),
+    onEnding: vi.fn(),
+    forceFlush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('FilteringSpanProcessor', () => {
+  it('forwards business spans to the delegate', () => {
+    const delegate = mockDelegate();
+    const processor = new FilteringSpanProcessor(delegate);
+    const span = makeSpan({
+      name: 'GET',
+      spanId: '1111111111111111',
+      attributes: { 'http.target': '/api/query/accounts' },
+    });
+    processor.onEnd(span);
+    expect(delegate.onEnd).toHaveBeenCalledWith(span);
+  });
+
+  it('drops health spans identified by http.target', () => {
+    const delegate = mockDelegate();
+    const processor = new FilteringSpanProcessor(delegate);
+    processor.onEnd(
+      makeSpan({
+        name: 'GET',
+        spanId: '2222222222222222',
+        attributes: { 'http.target': '/.well-known/healthcheck.json' },
+      })
+    );
+    expect(delegate.onEnd).not.toHaveBeenCalled();
+  });
+
+  it('drops Next.js spans that name the health route', () => {
+    const delegate = mockDelegate();
+    const processor = new FilteringSpanProcessor(delegate);
+    processor.onEnd(
+      makeSpan({
+        name: 'HEAD /api/health',
+        spanId: '3333333333333333',
+      })
+    );
+    processor.onEnd(
+      makeSpan({
+        name: 'executing api route (app) /api/health',
+        spanId: '4444444444444444',
+      })
+    );
+    expect(delegate.onEnd).not.toHaveBeenCalled();
+  });
+
+  it('drops descendants of a dropped health span (same parent)', () => {
+    const delegate = mockDelegate();
+    const processor = new FilteringSpanProcessor(delegate);
+    const parentId = '5555555555555555';
+    processor.onEnd(
+      makeSpan({
+        name: 'HEAD /api/health',
+        spanId: parentId,
+        traceId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })
+    );
+    processor.onEnd(
+      makeSpan({
+        name: 'start response',
+        spanId: '6666666666666666',
+        parentSpanId: parentId,
+        traceId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      })
+    );
+    expect(delegate.onEnd).not.toHaveBeenCalled();
+  });
+
+  it('drops later spans on a dropped health trace even without parent link', () => {
+    const delegate = mockDelegate();
+    const processor = new FilteringSpanProcessor(delegate);
+    const traceId = 'cccccccccccccccccccccccccccccccc';
+    processor.onEnd(
+      makeSpan({
+        name: 'GET',
+        spanId: '7777777777777777',
+        traceId,
+        attributes: { 'http.target': '/api/health' },
+      })
+    );
+    processor.onEnd(
+      makeSpan({
+        name: 'middleware GET',
+        spanId: '8888888888888888',
+        traceId,
+      })
+    );
+    expect(delegate.onEnd).not.toHaveBeenCalled();
+  });
+
+  it('forwards onStart / forceFlush / shutdown to the delegate', async () => {
+    const delegate = mockDelegate();
+    const processor = new FilteringSpanProcessor(delegate);
+    const span = {} as Span;
+    const ctx = {} as Context;
+    processor.onStart(span, ctx);
+    processor.onEnding(span);
+    await processor.forceFlush();
+    await processor.shutdown();
+    expect(delegate.onStart).toHaveBeenCalledWith(span, ctx);
+    expect(delegate.onEnding).toHaveBeenCalledWith(span);
+    expect(delegate.forceFlush).toHaveBeenCalledOnce();
+    expect(delegate.shutdown).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/telemetry-ignore.test.ts
+++ b/tests/unit/telemetry-ignore.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   incomingPathname,
+  pathFromSpanAttributes,
+  shouldDropHealthSpan,
   shouldIgnoreIncomingPath,
   shouldIgnoreOutgoingFetch,
   shouldIgnoreOutgoingHttp,
@@ -31,6 +33,42 @@ describe('shouldIgnoreIncomingPath', () => {
   it('treats missing url as not ignored', () => {
     expect(shouldIgnoreIncomingPath(undefined)).toBe(false);
     expect(incomingPathname(undefined)).toBe('');
+  });
+});
+
+describe('shouldDropHealthSpan', () => {
+  it('drops spans whose http.target is a health path', () => {
+    expect(
+      shouldDropHealthSpan('GET', { 'http.target': '/.well-known/healthcheck.json' })
+    ).toBe(true);
+    expect(
+      shouldDropHealthSpan('GET', { 'url.path': '/api/health' })
+    ).toBe(true);
+  });
+
+  it('drops Next.js spans that embed the health path in the name', () => {
+    expect(shouldDropHealthSpan('HEAD /api/health', {})).toBe(true);
+    expect(
+      shouldDropHealthSpan('executing api route (app) /api/health', undefined)
+    ).toBe(true);
+  });
+
+  it('keeps normal API and page spans', () => {
+    expect(
+      shouldDropHealthSpan('GET', { 'http.target': '/api/query/accounts' })
+    ).toBe(false);
+    expect(shouldDropHealthSpan('middleware GET', {})).toBe(false);
+    expect(shouldDropHealthSpan('start response', undefined)).toBe(false);
+  });
+});
+
+describe('pathFromSpanAttributes', () => {
+  it('prefers http.target then url.path', () => {
+    expect(pathFromSpanAttributes({ 'http.target': '/api/health?x=1' })).toBe(
+      '/api/health'
+    );
+    expect(pathFromSpanAttributes({ 'url.path': '/market' })).toBe('/market');
+    expect(pathFromSpanAttributes({})).toBe('');
   });
 });
 

--- a/tests/unit/telemetry-register.test.ts
+++ b/tests/unit/telemetry-register.test.ts
@@ -1,10 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const registerMock = vi.fn();
-const shutdownMock = vi.fn().mockResolvedValue(undefined);
-const setLoggerMock = vi.fn();
-const registerInstrumentationsMock = vi.fn();
-const resourceFromAttributesMock = vi.fn().mockReturnValue({ attributes: {} });
+const {
+  registerMock,
+  shutdownMock,
+  setLoggerMock,
+  registerInstrumentationsMock,
+  resourceFromAttributesMock,
+  providerConfigs,
+} = vi.hoisted(() => ({
+  registerMock: vi.fn(),
+  shutdownMock: vi.fn().mockResolvedValue(undefined),
+  setLoggerMock: vi.fn(),
+  registerInstrumentationsMock: vi.fn(),
+  resourceFromAttributesMock: vi.fn().mockReturnValue({ attributes: {} }),
+  providerConfigs: [] as unknown[],
+}));
 
 vi.mock('@opentelemetry/api', () => ({
   diag: { setLogger: (...args: unknown[]) => setLoggerMock(...args) },
@@ -59,9 +69,13 @@ vi.mock('@opentelemetry/resources', () => ({
 }));
 
 vi.mock('@opentelemetry/sdk-trace-node', () => ({
-  BatchSpanProcessor: class {},
+  BatchSpanProcessor: class {
+    constructor(public readonly exporter: unknown) {}
+  },
   NodeTracerProvider: class {
-    constructor(public readonly config: unknown) {}
+    constructor(public readonly config: unknown) {
+      providerConfigs.push(config);
+    }
     register(...args: unknown[]) {
       registerMock(...args);
     }
@@ -98,6 +112,7 @@ describe('registerTelemetry', () => {
     registerMock.mockClear();
     registerInstrumentationsMock.mockClear();
     setLoggerMock.mockClear();
+    providerConfigs.length = 0;
     for (const key of TELEMETRY_ENV_KEYS) {
       original[key] = process.env[key];
       delete process.env[key];
@@ -198,6 +213,17 @@ describe('registerTelemetry', () => {
         path: '/',
       })
     ).toBe(false);
+
+    const { FilteringSpanProcessor } = await import(
+      '@/lib/telemetry/filter-processor'
+    );
+    const providerConfig = providerConfigs[0] as {
+      spanProcessors: unknown[];
+    };
+    expect(providerConfig.spanProcessors).toHaveLength(1);
+    expect(providerConfig.spanProcessors[0]).toBeInstanceOf(
+      FilteringSpanProcessor
+    );
   });
 
   it('suppresses repeated OTLP export errors', async () => {


### PR DESCRIPTION
## Summary
- `HttpInstrumentation.ignoreIncomingRequestHook` only skips the outer Node HTTP span for `/api/health` and `/.well-known/healthcheck.json`; Next.js still emits framework spans (`HEAD /api/health`, `executing api route (app) /api/health`, middleware children, etc.) that flood OpenObserve.
- Add `FilteringSpanProcessor` that drops health spans by path attribute / span name, plus descendants on the same parent or trace, before `BatchSpanProcessor` export.
- Extend ignore helpers and unit tests for attribute/name matching and the filter processor.

## Test plan
- [ ] `pnpm exec vitest run tests/unit/telemetry-*.test.ts tests/unit/instrumentation.test.ts`
- [ ] Redeploy to `steemit-dev-wallet-001` and confirm OpenObserve `service_name=wallet` no longer shows healthcheck / `/api/health` spans after a few minutes of ELB probes
- [ ] Confirm business routes (`/api/query/*`, pages, `fetch POST https://api.steemitdev.com/`) still appear and wallet→jussi parent traces still link